### PR TITLE
Improve example test

### DIFF
--- a/pacesetter/Cargo.toml
+++ b/pacesetter/Cargo.toml
@@ -13,6 +13,7 @@ dotenvy = "0.15"
 figment = { version = "0.10", features = ["toml", "env"] }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] } 
+serde_json = "1.0"
 tokio = { version = "1.34", features = ["full"] }
 sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "migrate" ] }
 tower = { version = "0.4", features = ["util"] }
@@ -24,5 +25,4 @@ url = "2.5"
 validator = { version = "0.16", features = ["derive"] }
 
 [dev-dependencies]
-serde_json = "1.0"
 hyper = { version = "1.0", features = ["full"] }

--- a/template/web/src/controllers/example.rs
+++ b/template/web/src/controllers/example.rs
@@ -1,5 +1,13 @@
-use axum::response::Html;
+use axum::response::Json;
+use serde::{Deserialize, Serialize};
 
-pub async fn hello() -> Html<&'static str> {
-    Html("<h1>Hello, World!</h1>")
+#[derive(Deserialize, Serialize)]
+pub struct Message {
+    pub hello: String,
+}
+
+pub async fn hello() -> Json<Message> {
+    Json(Message {
+        hello: String::from("world"),
+    })
 }

--- a/template/web/src/lib.rs
+++ b/template/web/src/lib.rs
@@ -5,8 +5,8 @@ use pacesetter::{get_env, load_config};
 use tokio::net::TcpListener;
 use tracing::info;
 
-mod controllers;
-mod middlewares;
+pub mod controllers;
+pub mod middlewares;
 pub mod routes;
 pub mod state;
 

--- a/template/web/tests/example_test.rs
+++ b/template/web/tests/example_test.rs
@@ -1,5 +1,6 @@
 use axum::{body::Body, http::Method};
-use pacesetter::test::helpers::response_body;
+use {{crate_name}}_web::controllers::example::Message;
+use pacesetter::test::helpers::response_body_json;
 use pacesetter::test::helpers::{request, teardown, TestContext};
 use pacesetter_procs::test;
 use std::collections::HashMap;
@@ -17,6 +18,6 @@ async fn test_hello(context: &TestContext) {
     )
     .await;
 
-    let body = response_body(response).await;
-    assert_eq!(&body[..], b"<h1>Hello, World!</h1>");
+    let message: Message = response_body_json(response).await;
+    assert_eq!(message.hello, String::from("world"));
 }

--- a/template/web/tests/example_test.rs
+++ b/template/web/tests/example_test.rs
@@ -1,9 +1,8 @@
-use axum::response::Response;
 use axum::{body::Body, http::Method};
+use pacesetter::test::helpers::response_body;
 use pacesetter::test::helpers::{request, teardown, TestContext};
 use pacesetter_procs::test;
 use std::collections::HashMap;
-use pacesetter::test::helpers::response_body;
 
 mod common;
 
@@ -21,4 +20,3 @@ async fn test_hello(context: &TestContext) {
     let body = response_body(response).await;
     assert_eq!(&body[..], b"<h1>Hello, World!</h1>");
 }
-

--- a/template/web/tests/example_test.rs
+++ b/template/web/tests/example_test.rs
@@ -1,9 +1,9 @@
-use axum::body::Bytes;
 use axum::response::Response;
 use axum::{body::Body, http::Method};
 use pacesetter::test::helpers::{request, teardown, TestContext};
 use pacesetter_procs::test;
 use std::collections::HashMap;
+use pacesetter::test::helpers::response_body;
 
 mod common;
 
@@ -22,9 +22,3 @@ async fn test_hello(context: &TestContext) {
     assert_eq!(&body[..], b"<h1>Hello, World!</h1>");
 }
 
-async fn response_body(response: Response<Body>) -> Bytes {
-    // We don't care about the size limit in tests.
-    axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("Failed to read response body")
-}


### PR DESCRIPTION
This improves the example test by:

* moving the helper functions to parse the response body into pacesetter
* changing the example to be JSON instead