### PR TITLE
Better template dev experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
     name: Generate example app
     runs-on: ubuntu-latest
 
+    env:
+      PS_CLI_LOCAL_DEV: 1
+
     services:
       postgres:
         image: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,16 +94,6 @@ jobs:
       - name: generate
         run: cargo run --package pacesetter-cli my-app
 
-      - name: use-local-pacesetter
-        run: |
-          cd my-app/cli
-          cargo add pacesetter --path ../../pacesetter
-          cd ../config
-          cargo add pacesetter --path ../../pacesetter
-          cd ../web
-          cargo add pacesetter --path ../../pacesetter
-          cargo add --dev pacesetter-procs --path ../../pacesetter-procs
-
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: my-app

--- a/pacesetter-cli/src/main.rs
+++ b/pacesetter-cli/src/main.rs
@@ -30,8 +30,12 @@ fn main() {
     }
 }
 
-fn generate(name: &str, output_dir: Option<PathBuf>, local: bool) -> Result<PathBuf, anyhow::Error> {
-    if local {
+fn generate(
+    name: &str,
+    output_dir: Option<PathBuf>,
+    is_local: bool,
+) -> Result<PathBuf, anyhow::Error> {
+    if is_local {
         info("Using local template ./template");
     }
 
@@ -41,19 +45,7 @@ fn generate(name: &str, output_dir: Option<PathBuf>, local: bool) -> Result<Path
         env::current_dir()?
     };
 
-    let template_path = if local {
-        TemplatePath {
-            path: Some("./template".into()),
-            ..Default::default()
-        }
-    } else {
-        TemplatePath {
-            git: Some("https://github.com/marcoow/pacesetter".into()),
-            subfolder: Some("template".into()),
-            revision: Some(env!("VERGEN_GIT_SHA").into()),
-            ..Default::default()
-        }
-    };
+    let template_path = build_template_path(is_local);
 
     let generate_args = GenerateArgs {
         template_path,
@@ -67,6 +59,22 @@ fn generate(name: &str, output_dir: Option<PathBuf>, local: bool) -> Result<Path
         .context("failed to generate project from template")?;
 
     Ok(output_dir)
+}
+
+fn build_template_path(is_local: bool) -> TemplatePath {
+    if is_local {
+        TemplatePath {
+            path: Some("./template".into()),
+            ..Default::default()
+        }
+    } else {
+        TemplatePath {
+            git: Some("https://github.com/marcoow/pacesetter".into()),
+            subfolder: Some("template".into()),
+            revision: Some(env!("VERGEN_GIT_SHA").into()),
+            ..Default::default()
+        }
+    }
 }
 
 fn info(text: &str) {

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -4,4 +4,8 @@ resolver = "2"
 default-members = ["web"]
 
 [workspace.dependencies]
+{% if use_local_pacesetter -%}
+pacesetter = { path = "{{use_local_pacesetter}}" }
+{%- else -%}
 pacesetter = "0.0.1"
+{%- endif %}

--- a/template/web/Cargo.toml
+++ b/template/web/Cargo.toml
@@ -24,4 +24,8 @@ validator = { version = "0.16", features = ["derive"] }
 serde_json = "1.0"
 tower = { version = "0.4", features = ["util"] }
 hyper = { version = "1.0", features = ["full"] }
+{% if use_local_pacesetter_procs -%}
+pacesetter-procs = { path = "{{use_local_pacesetter_procs}}" }
+{%- else -%}
 pacesetter-procs = "0.0.1"
+{%- endif %}


### PR DESCRIPTION
This adds an env var `PS_CLI_LOCAL_DEV` that will make the CLI use the local template from `./template` and in the generated app, use the local `pacesetter` and `pacesetter-procs` so it's easier to work on the template and crate in combination.