### PR TITLE
Encapsulate all db access in db lib

### DIFF
--- a/blueprints/default/db/Cargo.toml
+++ b/blueprints/default/db/Cargo.toml
@@ -5,4 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
+anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono" ] }

--- a/blueprints/full/db/Cargo.toml
+++ b/blueprints/full/db/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono" ] }
 uuid = { version = "1.5", features = ["serde"] }

--- a/blueprints/full/db/Cargo.toml
+++ b/blueprints/full/db/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono" ] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "chrono" ] }
 uuid = { version = "1.5", features = ["serde"] }

--- a/blueprints/full/db/src/entities/mod.rs
+++ b/blueprints/full/db/src/entities/mod.rs
@@ -1,5 +1,2 @@
-mod task;
-mod user;
-
-pub use task::Task;
-pub use user::User;
+pub mod tasks;
+pub mod users;

--- a/blueprints/full/db/src/entities/task.rs
+++ b/blueprints/full/db/src/entities/task.rs
@@ -1,9 +1,0 @@
-use serde::Deserialize;
-use serde::Serialize;
-use uuid::Uuid;
-
-#[derive(Serialize, Debug, Deserialize)]
-pub struct Task {
-    pub id: Uuid,
-    pub description: String,
-}

--- a/blueprints/full/db/src/entities/tasks.rs
+++ b/blueprints/full/db/src/entities/tasks.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+use serde::Serialize;
+use sqlx::postgres::PgPool;
+use uuid::Uuid;
+
+#[derive(Serialize, Debug, Deserialize)]
+pub struct Task {
+    pub id: Uuid,
+    pub description: String,
+}
+
+pub async fn load_all(db: &PgPool) -> Result<Vec<Task>, anyhow::Error> {
+    let tasks = sqlx::query_as!(Task, "SELECT id, description FROM tasks")
+        .fetch_all(db)
+        .await?;
+    Ok(tasks)
+}
+
+pub async fn load(id: Uuid, db: &PgPool) -> Result<Task, anyhow::Error> {
+    let task = sqlx::query_as!(Task, "SELECT id, description FROM tasks WHERE id = $1", id)
+        .fetch_one(db)
+        .await?;
+    Ok(task)
+}
+
+pub async fn create(description: String, db: &PgPool) -> Result<Task, anyhow::Error> {
+    let record = sqlx::query!(
+        "INSERT INTO tasks (description) VALUES ($1) RETURNING id",
+        description
+    )
+    .fetch_one(db)
+    .await?;
+
+    Ok(Task {
+        id: record.id,
+        description,
+    })
+}

--- a/blueprints/full/db/src/entities/user.rs
+++ b/blueprints/full/db/src/entities/user.rs
@@ -1,8 +1,0 @@
-use serde::Serialize;
-use uuid::Uuid;
-
-#[derive(Serialize, Debug, Clone)]
-pub struct User {
-    pub id: Uuid,
-    pub name: String,
-}

--- a/blueprints/full/db/src/entities/users.rs
+++ b/blueprints/full/db/src/entities/users.rs
@@ -1,0 +1,16 @@
+use serde::Serialize;
+use sqlx::postgres::PgPool;
+use uuid::Uuid;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct User {
+    pub id: Uuid,
+    pub name: String,
+}
+
+pub async fn load_with_token(token: &str, db: &PgPool) -> Result<User, anyhow::Error> {
+    let user = sqlx::query_as!(User, "SELECT id, name FROM users WHERE token = $1", token)
+        .fetch_one(db)
+        .await?;
+    Ok(user)
+}

--- a/blueprints/full/web/Cargo.toml
+++ b/blueprints/full/web/Cargo.toml
@@ -13,7 +13,7 @@ rand = "0.8"
 {{project-name}}-config = { path = "../config" }
 {{project-name}}-db = { path = "../db" }
 serde = { version = "1.0", features = ["derive"] } 
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono" ] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "chrono" ] }
 tokio = { version = "1.34", features = ["full"] }
 tower-http = { version = "0.5", features = ["full"] }
 tracing = "0.1"

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -5,7 +5,7 @@ use axum::{
     http::{self, Method},
 };
 use hyper::StatusCode;
-use {{crate_name}}_db::entities::Task;
+use {{crate_name}}_db::entities::tasks::Task;
 use pacesetter::test::helpers::{request, DbTestContext};
 use pacesetter_procs::db_test;
 use serde::Serialize;


### PR DESCRIPTION
This moves all code (except for tests) that uses the database into the `db` crate for a cleaner architecture. That way, the `web` crate only deals with simple structs and we're not leaking all the DB complexity into it.