### PR TITLE
establish db connection in db crate

### DIFF
--- a/blueprints/full/db/Cargo.toml
+++ b/blueprints/full/db/Cargo.toml
@@ -9,6 +9,7 @@ test-helpers = []
 
 [dependencies]
 anyhow = "1.0"
+pacesetter = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "chrono" ] }
 uuid = { version = "1.5", features = ["serde"] }

--- a/blueprints/full/db/src/lib.rs
+++ b/blueprints/full/db/src/lib.rs
@@ -1,4 +1,17 @@
+use anyhow::{Context, Result};
+use pacesetter::config::DatabaseConfig;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
 pub mod entities;
+
+pub async fn connect_pool(config: DatabaseConfig) -> Result<PgPool, anyhow::Error> {
+    let pool = PgPoolOptions::new()
+        .connect(config.url.as_str())
+        .await
+        .context("Failed to connect to database")?;
+
+    Ok(pool)
+}
 
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;

--- a/blueprints/full/web/src/state.rs
+++ b/blueprints/full/web/src/state.rs
@@ -1,5 +1,6 @@
 use {{crate_name}}_config::Config;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use {{crate_name}}_db::connect_pool;
+use sqlx::postgres::PgPool;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -7,8 +8,7 @@ pub struct AppState {
 }
 
 pub async fn app_state(config: Config) -> AppState {
-    let db_pool = PgPoolOptions::new()
-        .connect(config.database.url.as_str())
+    let db_pool = connect_pool(config.database)
         .await
         .expect("Could not connect to database!");
 


### PR DESCRIPTION
This moves establishing the DB connection into the `db` crate so that all DB-related code is centralized there.