### PR TITLE
Drop sqlx dependency from web crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,7 @@ dependencies = [
  "figment",
  "hyper",
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "sqlx",

--- a/blueprints/default/db/src/lib.rs
+++ b/blueprints/default/db/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use pacesetter::config::DatabaseConfig;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPoolOptions;
 
 pub use sqlx::postgres::PgPool as DbPool;
 

--- a/blueprints/default/db/src/lib.rs
+++ b/blueprints/default/db/src/lib.rs
@@ -2,9 +2,11 @@ use anyhow::{Context, Result};
 use pacesetter::config::DatabaseConfig;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 
+pub use sqlx::postgres::PgPool as DbPool;
+
 pub mod entities;
 
-pub async fn connect_pool(config: DatabaseConfig) -> Result<PgPool, anyhow::Error> {
+pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Error> {
     let pool = PgPoolOptions::new()
         .connect(config.url.as_str())
         .await

--- a/blueprints/default/web/Cargo.toml
+++ b/blueprints/default/web/Cargo.toml
@@ -11,7 +11,6 @@ pacesetter = { workspace = true }
 {{project-name}}-config = { path = "../config" }
 {{project-name}}-db = { path = "../db" }
 serde = { version = "1.0", features = ["derive"] } 
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "migrate", "chrono" ] }
 tokio = { version = "1.34", features = ["full"] }
 tower-http = { version = "0.5", features = ["full"] }
 tracing = "0.1"

--- a/blueprints/default/web/src/state.rs
+++ b/blueprints/default/web/src/state.rs
@@ -1,10 +1,9 @@
 use {{crate_name}}_config::Config;
-use {{crate_name}}_db::connect_pool;
-use sqlx::postgres::PgPool;
+use {{crate_name}}_db::{connect_pool, DbPool};
 
 #[derive(Clone)]
 pub struct AppState {
-    pub db_pool: PgPool,
+    pub db_pool: DbPool,
 }
 
 pub async fn app_state(config: Config) -> AppState {

--- a/blueprints/default/web/tests/common/mod.rs
+++ b/blueprints/default/web/tests/common/mod.rs
@@ -23,5 +23,5 @@ pub async fn setup_with_db() -> DbTestContext {
         db_pool: db_pool.clone(),
     });
 
-    build_db_test_context(app, db_pool, db_config)
+    build_db_test_context(app, db_pool)
 }

--- a/blueprints/default/web/tests/common/mod.rs
+++ b/blueprints/default/web/tests/common/mod.rs
@@ -6,16 +6,14 @@ use pacesetter::{
     test::helpers::{build_db_test_context, prepare_db, DbTestContext},
     Environment,
 };
-use sqlx::postgres::PgPoolOptions;
 use std::cell::OnceCell;
 
 pub async fn setup_with_db() -> DbTestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
     let config = init_config.get_or_init(|| load_config(&Environment::Test));
 
-    let db_config = prepare_db(&config.database).await;
-    let db_pool = PgPoolOptions::new()
-        .connect_with(db_config.clone())
+    let test_db_config = prepare_db(&config.database).await;
+    let db_pool = connect_pool(test_db_config)
         .await
         .expect("Could not connect to database!");
 

--- a/blueprints/default/web/tests/common/mod.rs
+++ b/blueprints/default/web/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use {{crate_name}}_config::Config;
+use {{crate_name}}_db::connect_pool;
 use {{crate_name}}_web::routes::routes;
 use {{crate_name}}_web::state::AppState;
 use pacesetter::{

--- a/blueprints/full/db/src/entities/tasks.rs
+++ b/blueprints/full/db/src/entities/tasks.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
 use serde::Serialize;
-use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
 #[derive(Serialize, Debug, Deserialize)]
@@ -9,21 +8,21 @@ pub struct Task {
     pub description: String,
 }
 
-pub async fn load_all(db: &PgPool) -> Result<Vec<Task>, anyhow::Error> {
+pub async fn load_all(db: &crate::DbPool) -> Result<Vec<Task>, anyhow::Error> {
     let tasks = sqlx::query_as!(Task, "SELECT id, description FROM tasks")
         .fetch_all(db)
         .await?;
     Ok(tasks)
 }
 
-pub async fn load(id: Uuid, db: &PgPool) -> Result<Task, anyhow::Error> {
+pub async fn load(id: Uuid, db: &crate::DbPool) -> Result<Task, anyhow::Error> {
     let task = sqlx::query_as!(Task, "SELECT id, description FROM tasks WHERE id = $1", id)
         .fetch_one(db)
         .await?;
     Ok(task)
 }
 
-pub async fn create(description: String, db: &PgPool) -> Result<Task, anyhow::Error> {
+pub async fn create(description: String, db: &crate::DbPool) -> Result<Task, anyhow::Error> {
     let record = sqlx::query!(
         "INSERT INTO tasks (description) VALUES ($1) RETURNING id",
         description

--- a/blueprints/full/db/src/entities/users.rs
+++ b/blueprints/full/db/src/entities/users.rs
@@ -1,5 +1,4 @@
 use serde::Serialize;
-use sqlx::postgres::PgPool;
 use uuid::Uuid;
 
 #[derive(Serialize, Debug, Clone)]
@@ -8,7 +7,7 @@ pub struct User {
     pub name: String,
 }
 
-pub async fn load_with_token(token: &str, db: &PgPool) -> Result<Option<User>, anyhow::Error> {
+pub async fn load_with_token(token: &str, db: &crate::DbPool) -> Result<Option<User>, anyhow::Error> {
     match sqlx::query_as!(User, "SELECT id, name FROM users WHERE token = $1", token)
         .fetch_one(db)
         .await

--- a/blueprints/full/db/src/entities/users.rs
+++ b/blueprints/full/db/src/entities/users.rs
@@ -8,9 +8,15 @@ pub struct User {
     pub name: String,
 }
 
-pub async fn load_with_token(token: &str, db: &PgPool) -> Result<User, anyhow::Error> {
-    let user = sqlx::query_as!(User, "SELECT id, name FROM users WHERE token = $1", token)
+pub async fn load_with_token(token: &str, db: &PgPool) -> Result<Option<User>, anyhow::Error> {
+    match sqlx::query_as!(User, "SELECT id, name FROM users WHERE token = $1", token)
         .fetch_one(db)
-        .await?;
-    Ok(user)
+        .await
+    {
+        Ok(user) => Ok(Some(user)),
+        Err(error) => match error {
+            sqlx::Error::RowNotFound => Ok(None),
+            _ => Err(error.into()),
+        },
+    }
 }

--- a/blueprints/full/db/src/entities/users.rs
+++ b/blueprints/full/db/src/entities/users.rs
@@ -7,7 +7,10 @@ pub struct User {
     pub name: String,
 }
 
-pub async fn load_with_token(token: &str, db: &crate::DbPool) -> Result<Option<User>, anyhow::Error> {
+pub async fn load_with_token(
+    token: &str,
+    db: &crate::DbPool,
+) -> Result<Option<User>, anyhow::Error> {
     match sqlx::query_as!(User, "SELECT id, name FROM users WHERE token = $1", token)
         .fetch_one(db)
         .await

--- a/blueprints/full/db/src/lib.rs
+++ b/blueprints/full/db/src/lib.rs
@@ -1,10 +1,12 @@
 use anyhow::{Context, Result};
 use pacesetter::config::DatabaseConfig;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPoolOptions;
+
+pub use sqlx::postgres::PgPool as DbPool;
 
 pub mod entities;
 
-pub async fn connect_pool(config: DatabaseConfig) -> Result<PgPool, anyhow::Error> {
+pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Error> {
     let pool = PgPoolOptions::new()
         .connect(config.url.as_str())
         .await

--- a/blueprints/full/web/Cargo.toml
+++ b/blueprints/full/web/Cargo.toml
@@ -11,7 +11,6 @@ pacesetter = { workspace = true }
 {{project-name}}-config = { path = "../config" }
 {{project-name}}-db = { path = "../db" }
 serde = { version = "1.0", features = ["derive"] } 
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "chrono" ] }
 tokio = { version = "1.34", features = ["full"] }
 tower-http = { version = "0.5", features = ["full"] }
 tracing = "0.1"

--- a/blueprints/full/web/src/state.rs
+++ b/blueprints/full/web/src/state.rs
@@ -1,10 +1,9 @@
 use {{crate_name}}_config::Config;
-use {{crate_name}}_db::connect_pool;
-use sqlx::postgres::PgPool;
+use {{crate_name}}_db::{connect_pool, DbPool};
 
 #[derive(Clone)]
 pub struct AppState {
-    pub db_pool: PgPool,
+    pub db_pool: DbPool,
 }
 
 pub async fn app_state(config: Config) -> AppState {

--- a/blueprints/full/web/tests/common/mod.rs
+++ b/blueprints/full/web/tests/common/mod.rs
@@ -23,5 +23,5 @@ pub async fn setup_with_db() -> DbTestContext {
         db_pool: db_pool.clone(),
     });
 
-    build_db_test_context(app, db_pool, db_config)
+    build_db_test_context(app, db_pool)
 }

--- a/blueprints/full/web/tests/common/mod.rs
+++ b/blueprints/full/web/tests/common/mod.rs
@@ -6,16 +6,14 @@ use pacesetter::{
     test::helpers::{build_db_test_context, prepare_db, DbTestContext},
     Environment,
 };
-use sqlx::postgres::PgPoolOptions;
 use std::cell::OnceCell;
 
 pub async fn setup_with_db() -> DbTestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
     let config = init_config.get_or_init(|| load_config(&Environment::Test));
 
-    let db_config = prepare_db(&config.database).await;
-    let db_pool = PgPoolOptions::new()
-        .connect_with(db_config.clone())
+    let test_db_config = prepare_db(&config.database).await;
+    let db_pool = connect_pool(test_db_config)
         .await
         .expect("Could not connect to database!");
 

--- a/blueprints/full/web/tests/common/mod.rs
+++ b/blueprints/full/web/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use {{crate_name}}_config::Config;
+use {{crate_name}}_db::connect_pool;
 use {{crate_name}}_web::routes::routes;
 use {{crate_name}}_web::state::AppState;
 use pacesetter::{

--- a/pacesetter/Cargo.toml
+++ b/pacesetter/Cargo.toml
@@ -12,6 +12,7 @@ clap = "4.4"
 dotenvy = "0.15"
 figment = { version = "0.10", features = ["toml", "env"] }
 rand = "0.8"
+regex = "1.10"
 serde = { version = "1.0", features = ["derive"] } 
 serde_json = "1.0"
 tokio = { version = "1.34", features = ["full"] }

--- a/pacesetter/src/test/helpers.rs
+++ b/pacesetter/src/test/helpers.rs
@@ -8,10 +8,10 @@ use axum::{
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use sqlx::postgres::{PgConnectOptions, PgConnection};
-use sqlx::{ConnectOptions, Connection, Executor, PgPool};
+use sqlx::{Connection, Executor, PgPool};
 use std::collections::HashMap;
+use std::str::FromStr;
 use tower::ServiceExt;
-use url::Url;
 
 pub struct TestContext {
     pub app: Router,
@@ -113,6 +113,5 @@ fn build_test_db_name(base_name: &str) -> String {
 }
 
 fn parse_db_config(url: &str) -> PgConnectOptions {
-    let db_url = Url::parse(url).expect("Invalid DATABASE_URL!");
-    ConnectOptions::from_url(&db_url).expect("Invalid DATABASE_URL!")
+    PgConnectOptions::from_str(url).expect("Invalid DATABASE_URL!")
 }

--- a/pacesetter/src/test/helpers.rs
+++ b/pacesetter/src/test/helpers.rs
@@ -34,6 +34,7 @@ pub fn build_db_test_context(router: Router, db_pool: PgPool) -> DbTestContext {
     }
 }
 
+// TODO: this should be returning a DatabaseConfig so that in the web crate's tests/common/mod.rs, we can use the db crate's connect_pool function to establish a connection (and drop the sqlx dependency from the web crate)
 pub async fn prepare_db(config: &DatabaseConfig) -> PgConnectOptions {
     let db_config = parse_db_config(&config.url);
     let db_name = db_config.get_database().unwrap();


### PR DESCRIPTION
Since all of the DB access is encapsulated in the `db` crate, we can drop the `sqlx` dependency from the `web` crate.

## TODO

- [x] the middleware in the `full` blueprint still depends on sqlx to differentiate between row not found and general errors – the function should return a different error kind