### PR TITLE
introduce transactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
         cd my-app
         cargo run & (timeout 120 sh -c 'until nc -z $0 $1; do sleep 1; done' localhost 3000)
         curl -X POST localhost:3000/tasks -H 'Authorization: 9974812642a36dbee625fa06b2463dbff832e17dcce3836dbb' -H 'Content-Type: application/json' -d '{"description": "do something"}'
+        curl -X PUT localhost:3000/tasks -H 'Authorization: 9974812642a36dbee625fa06b2463dbff832e17dcce3836dbb' -H 'Content-Type: application/json' -d '[{"description": "do something else"}, {"description": "…and do another thing"}]'
         curl localhost:3000/tasks
 
   generate-default:

--- a/blueprints/default/db/src/lib.rs
+++ b/blueprints/default/db/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use pacesetter::config::DatabaseConfig;
-use sqlx::postgres::PgPoolOptions;
+use sqlx::{postgres::PgPoolOptions, Postgres, Transaction};
 use thiserror::Error;
 
 pub use sqlx::postgres::PgPool as DbPool;
@@ -14,6 +14,17 @@ pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Erro
         .context("Failed to connect to database")?;
 
     Ok(pool)
+}
+
+pub async fn transaction(
+    db_pool: &DbPool,
+) -> Result<Transaction<'static, Postgres>, anyhow::Error> {
+    let tx = db_pool
+        .begin()
+        .await
+        .context("Failed to begin transaction")?;
+
+    Ok(tx)
 }
 
 #[derive(Error, Debug)]

--- a/blueprints/full/db/src/entities/users.rs
+++ b/blueprints/full/db/src/entities/users.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use sqlx::Postgres;
 use uuid::Uuid;
 
 #[derive(Serialize, Debug, Clone)]
@@ -9,10 +10,10 @@ pub struct User {
 
 pub async fn load_with_token(
     token: &str,
-    db: &crate::DbPool,
+    executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<Option<User>, anyhow::Error> {
     match sqlx::query_as!(User, "SELECT id, name FROM users WHERE token = $1", token)
-        .fetch_one(db)
+        .fetch_one(executor)
         .await
     {
         Ok(user) => Ok(Some(user)),

--- a/blueprints/full/db/src/lib.rs
+++ b/blueprints/full/db/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use pacesetter::config::DatabaseConfig;
-use sqlx::postgres::PgPoolOptions;
+use sqlx::{postgres::PgPoolOptions, Postgres, Transaction};
 use thiserror::Error;
 
 pub use sqlx::postgres::PgPool as DbPool;
@@ -14,6 +14,17 @@ pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Erro
         .context("Failed to connect to database")?;
 
     Ok(pool)
+}
+
+pub async fn transaction(
+    db_pool: &DbPool,
+) -> Result<Transaction<'static, Postgres>, anyhow::Error> {
+    let tx = db_pool
+        .begin()
+        .await
+        .context("Failed to begin transaction")?;
+
+    Ok(tx)
 }
 
 #[derive(Error, Debug)]

--- a/blueprints/full/web/src/controllers/tasks.rs
+++ b/blueprints/full/web/src/controllers/tasks.rs
@@ -34,7 +34,8 @@ pub async fn create_task(
     State(app_state): State<AppState>,
     Json(task): Json<tasks::TaskChangeset>,
 ) -> Result<Json<tasks::Task>, (StatusCode, String)> {
-    match tasks::create(task, &app_state.db_pool).await {
+    let mut transaction = app_state.db_pool.begin().await.unwrap();
+    match tasks::create(task, &mut *transaction).await {
         Ok(task) => Ok(Json(task)),
         Err(Error::ValidationError(e)) => {
             info!(err.msg = %e, err.details = ?e, "Validation failed");

--- a/blueprints/full/web/src/controllers/tasks.rs
+++ b/blueprints/full/web/src/controllers/tasks.rs
@@ -34,18 +34,39 @@ pub async fn create_task(
     State(app_state): State<AppState>,
     Json(task): Json<tasks::TaskChangeset>,
 ) -> Result<Json<tasks::Task>, (StatusCode, String)> {
+    match tasks::create(task, &app_state.db_pool).await {
+        Ok(task) => Ok(Json(task)),
+        Err(Error::ValidationError(e)) => {
+            info!(err.msg = %e, err.details = ?e, "Validation failed");
+            Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))
+        }
+        Err(e) => Err((internal_error(e), "".into())),
+    }
+}
+
+pub async fn create_tasks(
+    State(app_state): State<AppState>,
+    Json(tasks): Json<Vec<tasks::TaskChangeset>>,
+) -> Result<Json<Vec<tasks::Task>>, (StatusCode, String)> {
     match transaction(&app_state.db_pool).await {
-        Ok(mut tx) => match tasks::create(task, &mut *tx).await {
-            Ok(task) => match tx.commit().await {
-                Ok(_) => Ok(Json(task)),
-                Err(e) => Err((internal_error(e), "".into())),
-            },
-            Err(Error::ValidationError(e)) => {
-                info!(err.msg = %e, err.details = ?e, "Validation failed");
-                Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))
+        Ok(mut tx) => {
+            let mut results: Vec<tasks::Task> = vec![];
+            for task in tasks {
+                match tasks::create(task, &mut *tx).await {
+                    Ok(task) => results.push(task),
+                    Err(Error::ValidationError(e)) => {
+                        info!(err.msg = %e, err.details = ?e, "Validation failed");
+                        return Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()));
+                    }
+                    Err(e) => return Err((internal_error(e), "".into())),
+                }
             }
-            Err(e) => Err((internal_error(e), "".into())),
-        },
+
+            match tx.commit().await {
+                Ok(_) => Ok(Json(results)),
+                Err(e) => Err((internal_error(e), "".into())),
+            }
+        }
         Err(e) => Err((internal_error(e), "".into())),
     }
 }

--- a/blueprints/full/web/src/controllers/tasks.rs
+++ b/blueprints/full/web/src/controllers/tasks.rs
@@ -1,6 +1,6 @@
 use crate::state::AppState;
 use axum::{extract::Path, extract::State, http::StatusCode, Json};
-use {{crate_name}}_db::{entities::tasks, Error};
+use {{crate_name}}_db::{entities::tasks, transaction, Error};
 use pacesetter::web::internal_error;
 use tracing::info;
 use uuid::Uuid;
@@ -34,16 +34,18 @@ pub async fn create_task(
     State(app_state): State<AppState>,
     Json(task): Json<tasks::TaskChangeset>,
 ) -> Result<Json<tasks::Task>, (StatusCode, String)> {
-    let mut transaction = app_state.db_pool.begin().await.unwrap();
-    match tasks::create(task, &mut *transaction).await {
-        Ok(task) => match transaction.commit().await {
-            Ok(_) => Ok(Json(task)),
+    match transaction(&app_state.db_pool).await {
+        Ok(mut tx) => match tasks::create(task, &mut *tx).await {
+            Ok(task) => match tx.commit().await {
+                Ok(_) => Ok(Json(task)),
+                Err(e) => Err((internal_error(e), "".into())),
+            },
+            Err(Error::ValidationError(e)) => {
+                info!(err.msg = %e, err.details = ?e, "Validation failed");
+                Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))
+            }
             Err(e) => Err((internal_error(e), "".into())),
         },
-        Err(Error::ValidationError(e)) => {
-            info!(err.msg = %e, err.details = ?e, "Validation failed");
-            Err((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))
-        }
         Err(e) => Err((internal_error(e), "".into())),
     }
 }

--- a/blueprints/full/web/src/routes.rs
+++ b/blueprints/full/web/src/routes.rs
@@ -1,4 +1,4 @@
-use crate::controllers::tasks::{create_task, get_task, get_tasks};
+use crate::controllers::tasks::{create_task, create_tasks, get_task, get_tasks};
 use crate::middlewares::auth::auth;
 use crate::state::AppState;
 use axum::{

--- a/blueprints/full/web/src/routes.rs
+++ b/blueprints/full/web/src/routes.rs
@@ -3,13 +3,14 @@ use crate::middlewares::auth::auth;
 use crate::state::AppState;
 use axum::{
     middleware,
-    routing::{get, post},
+    routing::{get, post, put},
     Router,
 };
 
 pub fn routes(app_state: AppState) -> Router {
     Router::new()
         .route("/tasks", post(create_task))
+        .route("/tasks", put(create_tasks))
         .route_layer(middleware::from_fn_with_state(app_state.clone(), auth))
         .route("/tasks", get(get_tasks))
         .route("/tasks/:id", get(get_task))

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -137,11 +137,13 @@ async fn test_create_tasks_invalid(context: &DbTestContext) {
     headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
     headers.insert(http::header::AUTHORIZATION.as_str(), "s3kuR t0k3n!");
 
-    let payload = json!(vec![TaskChangeset {
-        description: String::from("")
-    }, TaskChangeset {
-        description: String::from("do something")
-    }]);
+    let payload = json!(vec![
+        TaskChangeset {
+            description: String::from("")
+        }, TaskChangeset {
+            description: String::from("do something")
+        }
+    ]);
 
     let response = request(
         &context.app,
@@ -172,11 +174,13 @@ async fn test_create_tasks_authorized(context: &DbTestContext) {
     headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
     headers.insert(http::header::AUTHORIZATION.as_str(), "s3kuR t0k3n!");
 
-    let payload = json!(vec![TaskChangeset {
-        description: String::from("my task")
-    }, TaskChangeset {
-        description: String::from("my other task")
-    }]);
+    let payload = json!(vec![
+        TaskChangeset {
+            description: String::from("my task")
+        }, TaskChangeset {
+            description: String::from("my other task")
+        }
+    ]);
 
     let response = request(
         &context.app,

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -5,7 +5,9 @@ use axum::{
     http::{self, Method},
 };
 use hyper::StatusCode;
-use {{crate_name}}_db::entities::tasks::{create as create_task, load as load_task, load_all as load_tasks, Task, TaskChangeset};
+use {{crate_name}}_db::entities::tasks::{
+    create as create_task, load as load_task, load_all as load_tasks, Task, TaskChangeset
+};
 use {{crate_name}}_db::test_helpers::users::create as create_user;
 use pacesetter::test::helpers::{request, DbTestContext};
 use pacesetter_procs::db_test;

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -140,7 +140,8 @@ async fn test_create_tasks_invalid(context: &DbTestContext) {
     let payload = json!(vec![
         TaskChangeset {
             description: String::from("")
-        }, TaskChangeset {
+        },
+        TaskChangeset {
             description: String::from("do something")
         }
     ]);
@@ -177,7 +178,8 @@ async fn test_create_tasks_authorized(context: &DbTestContext) {
     let payload = json!(vec![
         TaskChangeset {
             description: String::from("my task")
-        }, TaskChangeset {
+        },
+        TaskChangeset {
             description: String::from("my other task")
         }
     ]);

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -38,7 +38,7 @@ async fn test_get_tasks(context: &DbTestContext) {
 
     let tasks: TasksList = json_body::<TasksList>(response).await;
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks.get(0).unwrap().description, "Test Task");
+    assert_eq!(tasks.first().unwrap().description, "Test Task");
 }
 
 #[db_test]

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -5,7 +5,7 @@ use axum::{
     http::{self, Method},
 };
 use hyper::StatusCode;
-use {{crate_name}}_db::entities::tasks::{create as create_task, Task, TaskChangeset};
+use {{crate_name}}_db::entities::tasks::{create as create_task, load as load_task, Task, TaskChangeset};
 use {{crate_name}}_db::test_helpers::users::create as create_user;
 use pacesetter::test::helpers::{request, DbTestContext};
 use pacesetter_procs::db_test;
@@ -36,7 +36,7 @@ async fn test_get_tasks(context: &DbTestContext) {
 
     let tasks: TasksList = json_body::<TasksList>(response).await;
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks.first().unwrap().description, "Test Task");
+    assert_eq!(tasks.get(0).unwrap().description, "Test Task");
 }
 
 #[db_test]
@@ -107,6 +107,9 @@ async fn test_create_tasks_authorized(context: &DbTestContext) {
     .await;
 
     let task: Task = json_body::<Task>(response).await;
+    assert_eq!(task.description, "my task");
+
+    let task = load_task(task.id, &context.db_pool).await.unwrap();
     assert_eq!(task.description, "my task");
 }
 

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use hyper::StatusCode;
 use {{crate_name}}_db::entities::tasks::{
-    create as create_task, load as load_task, load_all as load_tasks, Task, TaskChangeset
+    create as create_task, load as load_task, load_all as load_tasks, Task, TaskChangeset,
 };
 use {{crate_name}}_db::test_helpers::users::create as create_user;
 use pacesetter::test::helpers::{request, DbTestContext};

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -36,7 +36,7 @@ async fn test_get_tasks(context: &DbTestContext) {
 
     let tasks: TasksList = json_body::<TasksList>(response).await;
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks.get(0).unwrap().description, "Test Task");
+    assert_eq!(tasks.first().unwrap().description, "Test Task");
 }
 
 #[db_test]

--- a/blueprints/full/web/tests/tasks_test.rs
+++ b/blueprints/full/web/tests/tasks_test.rs
@@ -5,7 +5,7 @@ use axum::{
     http::{self, Method},
 };
 use hyper::StatusCode;
-use {{crate_name}}_db::entities::tasks::{create as create_task, load as load_task, Task, TaskChangeset};
+use {{crate_name}}_db::entities::tasks::{create as create_task, load as load_task, load_all as load_tasks, Task, TaskChangeset};
 use {{crate_name}}_db::test_helpers::users::create as create_user;
 use pacesetter::test::helpers::{request, DbTestContext};
 use pacesetter_procs::db_test;
@@ -36,11 +36,11 @@ async fn test_get_tasks(context: &DbTestContext) {
 
     let tasks: TasksList = json_body::<TasksList>(response).await;
     assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks.first().unwrap().description, "Test Task");
+    assert_eq!(tasks.get(0).unwrap().description, "Test Task");
 }
 
 #[db_test]
-async fn test_create_tasks_unauthorized(context: &DbTestContext) {
+async fn test_create_task_unauthorized(context: &DbTestContext) {
     let mut headers = HashMap::new();
     headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
 
@@ -50,7 +50,7 @@ async fn test_create_tasks_unauthorized(context: &DbTestContext) {
 }
 
 #[db_test]
-async fn test_create_tasks_invalid(context: &DbTestContext) {
+async fn test_create_task_invalid(context: &DbTestContext) {
     create_user(
         String::from("Test User"),
         String::from("s3kuR t0k3n!"),
@@ -80,7 +80,7 @@ async fn test_create_tasks_invalid(context: &DbTestContext) {
 }
 
 #[db_test]
-async fn test_create_tasks_authorized(context: &DbTestContext) {
+async fn test_create_task_authorized(context: &DbTestContext) {
     create_user(
         String::from("Test User"),
         String::from("s3kuR t0k3n!"),
@@ -111,6 +111,88 @@ async fn test_create_tasks_authorized(context: &DbTestContext) {
 
     let task = load_task(task.id, &context.db_pool).await.unwrap();
     assert_eq!(task.description, "my task");
+}
+
+#[db_test]
+async fn test_create_tasks_unauthorized(context: &DbTestContext) {
+    let mut headers = HashMap::new();
+    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
+
+    let response = request(&context.app, "/tasks", headers, Body::empty(), Method::PUT).await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[db_test]
+async fn test_create_tasks_invalid(context: &DbTestContext) {
+    create_user(
+        String::from("Test User"),
+        String::from("s3kuR t0k3n!"),
+        &context.db_pool,
+    )
+    .await
+    .unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
+    headers.insert(http::header::AUTHORIZATION.as_str(), "s3kuR t0k3n!");
+
+    let payload = json!(vec![TaskChangeset {
+        description: String::from("")
+    }, TaskChangeset {
+        description: String::from("do something")
+    }]);
+
+    let response = request(
+        &context.app,
+        "/tasks",
+        headers,
+        Body::from(payload.to_string()),
+        Method::PUT,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let tasks = load_tasks(&context.db_pool).await.unwrap();
+    assert_eq!(tasks.len(), 0);
+}
+
+#[db_test]
+async fn test_create_tasks_authorized(context: &DbTestContext) {
+    create_user(
+        String::from("Test User"),
+        String::from("s3kuR t0k3n!"),
+        &context.db_pool,
+    )
+    .await
+    .unwrap();
+
+    let mut headers = HashMap::new();
+    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
+    headers.insert(http::header::AUTHORIZATION.as_str(), "s3kuR t0k3n!");
+
+    let payload = json!(vec![TaskChangeset {
+        description: String::from("my task")
+    }, TaskChangeset {
+        description: String::from("my other task")
+    }]);
+
+    let response = request(
+        &context.app,
+        "/tasks",
+        headers,
+        Body::from(payload.to_string()),
+        Method::PUT,
+    )
+    .await;
+
+    let tasks: Vec<Task> = json_body::<Vec<Task>>(response).await;
+    assert_eq!(tasks.first().unwrap().description, "my task");
+    assert_eq!(tasks.get(1).unwrap().description, "my other task");
+
+    let tasks = load_tasks(&context.db_pool).await.unwrap();
+    assert_eq!(tasks.len(), 2);
 }
 
 #[db_test]


### PR DESCRIPTION
The helper functions in the DB crate now accept a DB pool as well as a transaction so that both of these work equally:

```rs
tasks::create(task, &app_state.db_pool).await
```

```rs
let mut transaction = app_state.db_pool.begin().await.unwrap();
tasks::create(task, &mut *transaction).await;
transaction.commit.await;
```

## TODO

- [x] add `transaction` function to db crate (re-exported from pacesetter)
- [x] add proper transactions example (e.g. batch creation of tasks)