### PR TITLE
cleanup tests

### DIFF
--- a/pacesetter/src/cli/generate/blueprints/controller/crud/test.rs.liquid
+++ b/pacesetter/src/cli/generate/blueprints/controller/crud/test.rs.liquid
@@ -1,5 +1,3 @@
-use axum::body::Bytes;
-use axum::response::Response;
 use axum::{
     body::Body,
     http::{self, Method},
@@ -7,7 +5,7 @@ use axum::{
 use fake::{Fake, Faker};
 use hyper::StatusCode;
 use {{db_crate_name}}::{entities, transaction, Error};
-use pacesetter::test::helpers::{request, DbTestContext};
+use pacesetter::test::helpers::{request, response_body_json, DbTestContext};
 use pacesetter_procs::db_test;
 use serde_json::json;
 use std::collections::HashMap;
@@ -92,7 +90,7 @@ async fn test_read_all(context: &DbTestContext) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let {{entity_plural_name}}: Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}> = json_body::<Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}>>(response).await;
+    let {{entity_plural_name}}: Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}> = response_body_json::<Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}>>(response).await;
     assert_eq!({{entity_plural_name}}.len(), 1);
     assert_eq!(
         {{entity_plural_name}}.first().unwrap().description,
@@ -141,7 +139,7 @@ async fn test_read_one_success(context: &DbTestContext) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = json_body::<entities::{{entity_plural_name}}::{{entity_struct_name}}>(response).await;
+    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = response_body_json::<entities::{{entity_plural_name}}::{{entity_struct_name}}>(response).await;
     assert_eq!({{entity_singular_name}}.id, {{entity_singular_name}}_id);
     assert_eq!({{entity_singular_name}}.description, {{entity_singular_name}}_changeset.description);
     */
@@ -231,7 +229,7 @@ async fn test_update_success(context: &DbTestContext) {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = json_body::<Task>(response).await;
+    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = response_body_json::<Task>(response).await;
     assert_eq!({{entity_singular_name}}.description, {{entity_singular_name}}_changeset.description);
 
     let {{entity_singular_name}} = load_{{entity_singular_name}}({{entity_singular_name}}.id, &context.db_pool).await.unwrap();
@@ -281,19 +279,4 @@ async fn test_delete_success(context: &DbTestContext) {
     let result = load_{{entity_singular_name}}({{entity_singular_name}}.id, &context.db_pool).await;
     assert!(result.is_err());
     */
-}
-
-async fn json_body<T>(response: Response<Body>) -> T
-where
-    T: serde::de::DeserializeOwned,
-{
-    let body = response_body(response).await;
-    serde_json::from_slice::<T>(&body).expect("Failed to deserialize JSON body")
-}
-
-async fn response_body(response: Response<Body>) -> Bytes {
-    // We don't care about the size limit in tests.
-    axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("Failed to read response body")
 }

--- a/pacesetter/src/cli/generate/blueprints/controller/minimal/test.rs.liquid
+++ b/pacesetter/src/cli/generate/blueprints/controller/minimal/test.rs.liquid
@@ -1,7 +1,6 @@
-use axum::response::Response;
 use axum::{body::Body, http::Method};
 use hyper::StatusCode;
-use pacesetter::test::helpers::{request, DbTestContext};
+use pacesetter::test::helpers::{request, response_body, DbTestContext};
 use pacesetter_procs::db_test;
 use std::collections::HashMap;
 


### PR DESCRIPTION
Use pacesetter's test helpers for parsing responses instead of inline implementations.