### PR TITLE
Add `cli` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,21 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,22 +122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
-dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -315,27 +284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -582,15 +530,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -848,16 +787,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flume"
@@ -1409,12 +1338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
-
-[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,16 +1502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1860,16 +1773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,9 +2002,6 @@ dependencies = [
  "hyper",
  "include_dir",
  "liquid",
- "liquid-core",
- "liquid-derive",
- "liquid-lib",
  "pacesetter-util",
  "rand",
  "regex",
@@ -2110,7 +2010,6 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
- "tower-http",
  "tracing",
  "tracing-panic",
  "tracing-subscriber",
@@ -3420,37 +3319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da193277a4e2c33e59e09b5861580c33dd0a637c3883d0fa74ba40c0374af2e"
-dependencies = [
- "async-compression",
- "base64",
- "bitflags 2.4.2",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3562,15 +3430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,15 +3502,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "validator"
@@ -4040,31 +3890,3 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-
-[[package]]
-name = "zstd"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/pacesetter-cli/blueprints/default/cli/Cargo.toml
+++ b/pacesetter-cli/blueprints/default/cli/Cargo.toml
@@ -13,6 +13,6 @@ name = "generate"
 path = "src/bin/generate.rs"
 
 [dependencies]
-pacesetter = { workspace = true }
+pacesetter = { workspace = true, features = ["cli"] }
 {{project-name}}-config = { path = "../config" }
 tokio = { version = "1.34", features = ["full"] }

--- a/pacesetter-cli/blueprints/full/cli/Cargo.toml
+++ b/pacesetter-cli/blueprints/full/cli/Cargo.toml
@@ -13,6 +13,6 @@ name = "generate"
 path = "src/bin/generate.rs"
 
 [dependencies]
-pacesetter = { workspace = true }
+pacesetter = { workspace = true, features = ["cli"] }
 {{project-name}}-config = { path = "../config" }
 tokio = { version = "1.34", features = ["full"] }

--- a/pacesetter/Cargo.toml
+++ b/pacesetter/Cargo.toml
@@ -9,31 +9,38 @@ license = "MIT"
 [lib]
 doctest = false
 
+[features]
+default = []
+cli = ["clap", "pacesetter-util", "include_dir", "cruet", "guppy", "liquid"]
+
 [dependencies]
-anyhow = "1"
-axum = "0.7"
-clap = { version = "4.4", features = ["derive"] }
-cruet = "0.14"
-dotenvy = "0.15"
+# Config
 figment = { version = "0.10", features = ["toml", "env"] }
-guppy = "0.17"
-include_dir = "0.7"
-liquid = "~0.26"
-liquid-core = "~0.26"
-liquid-lib = "~0.26"
-liquid-derive = "~0.26"
+dotenvy = "0.15"
+anyhow = "1"
+
+# Tracing
+tracing = "0.1"
+tracing-panic = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "fmt"] }
+
+axum = "0.7"
+
+# Cli
+pacesetter-util = { path = "../pacesetter-util", optional = true }
+clap = { version = "4.4", features = ["derive"], optional = true }
+include_dir = { version = "0.7", optional = true }
+cruet = { version = "0.14", optional = true }
+guppy = { version = "0.17", optional = true }
+liquid = { version = "~0.26", optional = true }
+
 rand = "0.8"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] } 
 serde_json = "1.0"
 tokio = { version = "1.34", features = ["full"] }
-pacesetter-util = { path = "../pacesetter-util" }
 sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls", "postgres", "migrate" ] }
 tower = { version = "0.4", features = ["util"] }
-tower-http = { version = "0.5", features = ["full"] }
-tracing = "0.1"
-tracing-panic = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "fmt"] }
 url = "2.5"
 validator = { version = "0.16", features = ["derive"] }
 

--- a/pacesetter/src/lib.rs
+++ b/pacesetter/src/lib.rs
@@ -7,6 +7,7 @@
 //! [axum]: https://github.com/tokio-rs/axum
 
 #[doc(hidden)]
+#[cfg(feature = "cli")]
 pub mod cli;
 
 /// Confuguration handling structs and utilities


### PR DESCRIPTION
The `pacesetter` crate is a runtime dependency of the generated project.
We need to minimise its dependency footprint to reduce compilation times, both for getting started on a project and iterating.

This PR adds a `cli` feature that gates all dependencies only required when using generators. The generated API project will therefore no longer need to compile `clap` or `liquid`.