### PR TITLE
use new test APIs in generated files consistently

### DIFF
--- a/blueprint/cli/blueprints/controller/crud/test.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/crud/test.rs.liquid.liquid
@@ -1,4 +1,4 @@
-use crate::common::{request, response_body_json, DbTestContext};
+use crate::common::{BodyExt, DbTestContext, RouterExt};
 use axum::{
     body::Body,
     http::{self, Method},
@@ -19,21 +19,18 @@ async fn test_create_invalid(context: &DbTestContext) {
     todo!("send invalid changeset, assert 422 response!");
 
     /* Example:
-    let mut headers = HashMap::new();
-    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
-
     let payload = json!(entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset {
         description: String::from("")
     });
 
-    let response = request(
-        &context.app,
-        "/{{entity_plural_name}}",
-        headers,
-        Body::from(payload.to_string()),
-        Method::POST,
-    )
-    .await;
+    let response = context
+        .app
+        .request("/{{entity_plural_name}}")
+        .method(Method::POST)
+        .body(payload.to_string())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::UNPROCESSABLE_ENTITY));
     */
@@ -44,20 +41,17 @@ async fn test_create_success(context: &DbTestContext) {
     todo!("send valid changeset, assert 201 response!");
 
     /* Example:
-    let mut headers = HashMap::new();
-    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
-
     let changeset: entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset = Faker.fake();
     let payload = json!(changeset);
 
-    let response = request(
-        &context.app,
-        "/{{entity_plural_name}}",
-        headers,
-        Body::from(payload.to_string()),
-        Method::POST,
-    )
-    .await;
+    let response = context
+        .app
+        .request("/{{entity_plural_name}}")
+        .method(Method::POST)
+        .body(payload.to_string())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::CREATED));
 
@@ -80,18 +74,15 @@ async fn test_read_all(context: &DbTestContext) {
         .await
         .unwrap();
 
-    let response = request(
-        &context.app,
-        "/{{entity_plural_name}}",
-        HashMap::new(),
-        Body::empty(),
-        Method::GET,
-    )
-    .await;
+    let response = context
+        .app
+        .request("/{{entity_plural_name}}")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::OK));
 
-    let {{entity_plural_name}}: Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}> = response_body_json::<Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}>>(response).await;
+    let {{entity_plural_name}}: Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}> = response.into_body.into_json::<Vec<entities::{{entity_plural_name}}::{{entity_struct_name}}>>(response).await;
     assert_that!({{entity_plural_name}}, len(eq(1)));
     assert_that!(
         {{entity_plural_name}}.first().unwrap().description,
@@ -105,14 +96,12 @@ async fn test_read_one_nonexistent(context: &DbTestContext) {
     todo!("read non-existent entity, assert 404 response!");
 
     /* Example:
-    let response = request(
-        &context.app,
-        format!("/{{entity_plural_name}}/{}", Uuid::new_v4()).as_str(),
-        HashMap::new(),
-        Body::empty(),
-        Method::GET,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", Uuid::new_v4()))
+        .body(payload.to_string())
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::NOT_FOUND));
     */
@@ -129,18 +118,15 @@ async fn test_read_one_success(context: &DbTestContext) {
         .unwrap();
     let {{entity_singular_name}}_id = {{entity_singular_name}}.id;
 
-    let response = request(
-        &context.app,
-        format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}_id).as_str(),
-        HashMap::new(),
-        Body::empty(),
-        Method::GET,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}_id))
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::OK));
 
-    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = response_body_json::<entities::{{entity_plural_name}}::{{entity_struct_name}}>(response).await;
+    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = response.into_body().into_json::<entities::{{entity_plural_name}}::{{entity_struct_name}}>(response).await;
     assert_that!({{entity_singular_name}}.id, eq({{entity_singular_name}}_id));
     assert_that!({{entity_singular_name}}.description, eq({{entity_singular_name}}_changeset.description));
     */
@@ -156,21 +142,18 @@ async fn test_update_invalid(context: &DbTestContext) {
         .await
         .unwrap();
 
-    let mut headers = HashMap::new();
-    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
-
     let payload = json!(entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset {
         description: String::from("")
     });
 
-    let response = request(
-        &context.app,
-        &format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}.id),
-        headers,
-        Body::from(payload.to_string()),
-        Method::PUT,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}_id))
+        .method(Method::PUT)
+        .body(payload.to_string())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::UNPROCESSABLE_ENTITY));
 
@@ -184,20 +167,17 @@ async fn test_update_nonexistent(context: &DbTestContext) {
     todo!("send valid changeset for non-existent ID, assert 404 response!");
 
     /* Example:
-    let mut headers = HashMap::new();
-    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
-
     let {{entity_singular_name}}_changeset: entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset = Faker.fake();
     let payload = json!({{entity_singular_name}}_changeset);
 
-    let response = request(
-        &context.app,
-        &format!("/{{entity_plural_name}}/{}", Uuid::new_v4()),
-        headers,
-        Body::from(payload.to_string()),
-        Method::PUT,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", Uuid::new_v4()))
+        .method(Method::PUT)
+        .body(payload.to_string())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::NOT_FOUND));
     */
@@ -213,24 +193,21 @@ async fn test_update_success(context: &DbTestContext) {
         .await
         .unwrap();
 
-    let mut headers = HashMap::new();
-    headers.insert(http::header::CONTENT_TYPE.as_str(), "application/json");
-
     let {{entity_singular_name}}_changeset: entities::{{entity_plural_name}}::{{entity_struct_name}}Changeset = Faker.fake();
     let payload = json!({{entity_singular_name}}_changeset);
 
-    let response = request(
-        &context.app,
-        &format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}.id),
-        headers,
-        Body::from(payload.to_string()),
-        Method::PUT,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}.id))
+        .method(Method::PUT)
+        .body(payload.to_string())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::OK));
 
-    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = response_body_json::<Task>(response).await;
+    let {{entity_singular_name}}: entities::{{entity_plural_name}}::{{entity_struct_name}} = response.into_body.into_json::<Task>(response).await;
     assert_that!({{entity_singular_name}}.description, eq({{entity_singular_name}}_changeset.description.clone()));
 
     let {{entity_singular_name}} = load_{{entity_singular_name}}({{entity_singular_name}}.id, &context.db_pool).await.unwrap();
@@ -243,14 +220,12 @@ async fn test_delete_nonexistent(context: &DbTestContext) {
     todo!("delete non-existing ID, assert 404 response!");
 
     /* Example:
-    let response = request(
-        &context.app,
-        &format!("/{{entity_plural_name}}/{}", Uuid::new_v4()),
-        HashMap::<&str, &str>::new(),
-        Body::empty(),
-        Method::DELETE,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", Uuid::new_v4()))
+        .method(Method::DELETE)
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::NOT_FOUND));
     */
@@ -266,14 +241,12 @@ async fn test_delete_success(context: &DbTestContext) {
         .await
         .unwrap();
 
-    let response = request(
-        &context.app,
-        &format!("/{{entity_plural_name}}/{}", {{entity_singular_name}}.id),
-        HashMap::<&str, &str>::new(),
-        Body::empty(),
-        Method::DELETE,
-    )
-    .await;
+    let response = context
+        .app
+        .request(&format!("/{{entity_plural_name}}/{}", Uuid::new_v4()))
+        .method(Method::DELETE)
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::NO_CONTENT));
 

--- a/blueprint/cli/blueprints/controller/minimal/test.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/minimal/test.rs.liquid.liquid
@@ -1,25 +1,22 @@
-use crate::common::{request, response_body, DbTestContext};
+use crate::common::{request, response_body, TestContext};
 use axum::{body::Body, http::Method};
 use googletest::prelude::*;
 use hyper::StatusCode;
-use {{macros_crate_name}}::db_test;
+use {{macros_crate_name}}::test;
 use std::collections::HashMap;
 
 use crate::common;
 
-#[db_test]
-async fn test_action(context: &DbTestContext) {
+#[test]
+async fn test_action(context: &TestContext) {
     todo!("implement and assert on status code!");
 
     /* Example:
-    let response = request(
-        &context.app,
-        "/{{name}}/action",
-        HashMap::new(),
-        Body::empty(),
-        Method::GET,
-    )
-    .await;
+    let response = context
+        .app
+        .request("/{{name}}/action")
+        .send()
+        .await;
 
     assert_that!(response.status(), eq(StatusCode::OK));
     */


### PR DESCRIPTION
This is a follow-up to #39 and #40 which missed updating the blueprints for generating controllers