### PR TITLE
Add code docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,13 @@ jobs:
         cd my-app
         cargo doc --workspace --all-features --no-deps
 
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+      with:
+        name: docs
+        path: my-app/target/doc
+        if-no-files-found: error
+        retention-days: 3
+
   run-generated-full:
     name: "Run generated full example app"
     runs-on: ubuntu-latest
@@ -383,6 +390,13 @@ jobs:
       run: |
         cd my-app
         cargo doc --workspace --all-features --no-deps
+
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+      with:
+        name: docs
+        path: my-app/target/doc
+        if-no-files-found: error
+        retention-days: 3
 
   run-generators-with-generated-default:
     name: "Run generators on generated default example app"
@@ -579,6 +593,13 @@ jobs:
       run: |
         cd my-app
         cargo doc --workspace --no-deps
+
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+      with:
+        name: docs
+        path: my-app/target/doc
+        if-no-files-found: error
+        retention-days: 3
 
   clippy-generated-minimal:
     name: "Run Clippy on generated minimal example app"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         components: clippy
 
     - name: clippy
+      env:
+        RUSTFLAGS: "-D missing-docs"
       run: cargo clippy --all-targets -- -D warnings
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,47 @@ jobs:
         cd my-app
         cargo clippy --all-targets -- -D warnings
 
+  doc-generated-full:
+    name: "Build docs for generated full example app"
+    runs-on: ubuntu-latest
+    needs: generate-full
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: my_app
+          POSTGRES_USER: my_app
+          POSTGRES_PASSWORD: my_app
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
+      with:
+        name: my-app-full
+        path: my-app
+
+    - name: migrate
+      run: |
+        cd my-app
+        cargo db reset
+
+    - name: doc-generated
+      env:
+        RUSTFLAGS: "-D missing-docs"
+      run: |
+        cd my-app
+        cargo doc --workspace --all-features --no-deps
+
   run-generated-full:
     name: "Run generated full example app"
     runs-on: ubuntu-latest
@@ -301,7 +342,48 @@ jobs:
       run: |
         cd my-app
         cargo fmt --all -- --check
-  
+
+  doc-generated-default:
+    name: "Build docs for generated default example app"
+    runs-on: ubuntu-latest
+    needs: generate-default
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: my_app
+          POSTGRES_USER: my_app
+          POSTGRES_PASSWORD: my_app
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
+      with:
+        name: my-app-default
+        path: my-app
+
+    - name: migrate
+      run: |
+        cd my-app
+        cargo db reset
+
+    - name: doc-generated
+      env:
+        RUSTFLAGS: "-D missing-docs"
+      run: |
+        cd my-app
+        cargo doc --workspace --all-features --no-deps
+
   run-generators-with-generated-default:
     name: "Run generators on generated default example app"
     runs-on: ubuntu-latest
@@ -476,7 +558,28 @@ jobs:
       run: |
         cd my-app
         cargo fmt --all -- --check
-  
+
+  doc-generated-minimal:
+    name: "Build docs for generated minimal example app"
+    runs-on: ubuntu-latest
+    needs: generate-minimal
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
+      with:
+        name: my-app-minimal
+        path: my-app
+
+    - name: doc-generated
+      env:
+        RUSTFLAGS: "-D missing-docs"
+      run: |
+        cd my-app
+        cargo doc --workspace --no-deps
+
   clippy-generated-minimal:
     name: "Run Clippy on generated minimal example app"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
         cargo db reset
 
     - name: clippy-generated
+      env:
+        RUSTFLAGS: "-D missing-docs"
       run: |
         cd my-app
         cargo clippy --all-targets -- -D warnings
@@ -210,8 +212,6 @@ jobs:
         cargo db reset
 
     - name: doc-generated
-      env:
-        RUSTFLAGS: "-D missing-docs"
       run: |
         cd my-app
         cargo doc --workspace --all-features --no-deps
@@ -385,8 +385,6 @@ jobs:
         cargo db reset
 
     - name: doc-generated
-      env:
-        RUSTFLAGS: "-D missing-docs"
       run: |
         cd my-app
         cargo doc --workspace --all-features --no-deps
@@ -479,6 +477,8 @@ jobs:
         path: my-app
   
     - name: clippy-generated
+      env:
+        RUSTFLAGS: "-D missing-docs"
       run: |
         cd my-app
         cargo clippy --all-targets -- -D warnings
@@ -588,8 +588,6 @@ jobs:
         path: my-app
 
     - name: doc-generated
-      env:
-        RUSTFLAGS: "-D missing-docs"
       run: |
         cd my-app
         cargo doc --workspace --no-deps
@@ -616,6 +614,8 @@ jobs:
         path: my-app
   
     - name: clippy-generated
+      env:
+        RUSTFLAGS: "-D missing-docs"
       run: |
         cd my-app
         cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
 
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
       with:
-        name: docs
+        name: docs-full
         path: my-app/target/doc
         if-no-files-found: error
         retention-days: 3
@@ -393,7 +393,7 @@ jobs:
 
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
       with:
-        name: docs
+        name: docs-default
         path: my-app/target/doc
         if-no-files-found: error
         retention-days: 3
@@ -596,7 +596,7 @@ jobs:
 
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
       with:
-        name: docs
+        name: docs-minimal
         path: my-app/target/doc
         if-no-files-found: error
         retention-days: 3

--- a/blueprint/README.md.liquid
+++ b/blueprint/README.md.liquid
@@ -73,9 +73,5 @@ Building the project's docs:
 Build the project's documentation with:
 
 ```
-{% if template_type == "minimal" -%}
-cargo doc --workspace
-{%- else -%}
 cargo doc --workspace --all-features
-{%- endif %}
 ```

--- a/blueprint/README.md.liquid
+++ b/blueprint/README.md.liquid
@@ -65,3 +65,17 @@ Generating project files like entities, controllers, tests, etc. (see the [CLI c
 ```
 cargo generate
 ```
+
+Building the project's docs:
+
+## Building documentation
+
+Build the project's documentation with:
+
+```
+{% if template_type == "minimal" -%}
+cargo doc --workspace
+{%- else -%}
+cargo doc --workspace --all-features
+{%- endif %}
+```

--- a/blueprint/cli/Cargo.toml.liquid
+++ b/blueprint/cli/Cargo.toml.liquid
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
+# examples in docs don't run without additional setup
 doctest = false
 
 {% if template_type != "minimal" -%}

--- a/blueprint/cli/blueprints/controller/crud/test.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/crud/test.rs.liquid.liquid
@@ -1,4 +1,4 @@
-use crate::common::{BodyExt, DbTestContext, RouterExt};
+use crate::test_helpers::{BodyExt, DbTestContext, RouterExt};
 use axum::{
     body::Body,
     http::{self, Method},

--- a/blueprint/cli/blueprints/controller/minimal/test.rs.liquid.liquid
+++ b/blueprint/cli/blueprints/controller/minimal/test.rs.liquid.liquid
@@ -1,7 +1,7 @@
 {%- if has_db -%}
-use crate::common::{BodyExt, DbTestContext, RouterExt};
+use crate::test_helpers::{BodyExt, DbTestContext, RouterExt};
 {% else %}
-use crate::common::{BodyExt, TestContext, RouterExt};
+use crate::test_helpers::{BodyExt, TestContext, RouterExt};
 {%- endif -%}
 use axum::{body::Body, http::Method};
 use googletest::prelude::*;

--- a/blueprint/cli/src/bin/db.rs
+++ b/blueprint/cli/src/bin/db.rs
@@ -1,8 +1,7 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
-use {{crate_name}}_cli::util::parse_env;
 use {{crate_name}}_cli::util::ui::UI;
-use {{crate_name}}_config::{load_config, Config, Environment};
+use {{crate_name}}_config::{load_config, parse_env, Config, Environment};
 use {{crate_name}}_config::DatabaseConfig;
 use sqlx::postgres::{PgConnectOptions, PgConnection};
 use sqlx::{

--- a/blueprint/cli/src/lib.rs
+++ b/blueprint/cli/src/lib.rs
@@ -1,1 +1,4 @@
+//! The {{project-name}}-cli crate implements the project's CLI tools `db` and `generate` as well as contains functionality for displaying information in a console UI.
+
+/// Utilities for CLIs
 pub mod util;

--- a/blueprint/cli/src/util/mod.rs
+++ b/blueprint/cli/src/util/mod.rs
@@ -1,8 +1,12 @@
 use anyhow::anyhow;
 use {{crate_name}}_config::Environment;
 
+/// Utilities for console UIs
 pub mod ui;
 
+/// Parses the [`my_app_config::Environment`] the CLI runs in from a string.
+///
+/// The environment can be passed in different forms, e.g. "dev", "development", "prod", etc. If an invalid environment is passed, this returns an error.
 pub fn parse_env(s: &str) -> Result<Environment, &'static str> {
     let s = &s.to_lowercase();
     match parse_env_internal(s) {

--- a/blueprint/cli/src/util/mod.rs
+++ b/blueprint/cli/src/util/mod.rs
@@ -1,28 +1,2 @@
-use anyhow::anyhow;
-use {{crate_name}}_config::Environment;
-
 /// Utilities for console UIs
 pub mod ui;
-
-/// Parses the [`my_app_config::Environment`] the CLI runs in from a string.
-///
-/// The environment can be passed in different forms, e.g. "dev", "development", "prod", etc. If an invalid environment is passed, this returns an error.
-pub fn parse_env(s: &str) -> Result<Environment, &'static str> {
-    let s = &s.to_lowercase();
-    match parse_env_internal(s) {
-        Ok(env) => Ok(env),
-        Err(_) => Err("Cannot parse environment!"),
-    }
-}
-
-fn parse_env_internal(env: &str) -> Result<Environment, anyhow::Error> {
-    let env = &env.to_lowercase();
-    match env.as_str() {
-        "dev" => Ok(Environment::Development),
-        "development" => Ok(Environment::Development),
-        "test" => Ok(Environment::Test),
-        "prod" => Ok(Environment::Production),
-        "production" => Ok(Environment::Production),
-        unknown => Err(anyhow!(r#"Unknown environment: "{}"!"#, unknown)),
-    }
-}

--- a/blueprint/config/Cargo.toml.liquid
+++ b/blueprint/config/Cargo.toml.liquid
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
+# examples in docs don't run without config files being in place, etc.
 doctest = false
 
 [dependencies]

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -10,6 +10,11 @@ use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tracing::info;
 
+/// The application configuration.
+///
+/// This struct is the central point for the entire application configuration. It holds the [`ServerConfig`] {% unless template_type == "minimal" -%}as well as [`DatabaseConfig`] {%- endunless %}and can be extended with any application-specific configuration settings that will be read from the main `app.toml` and the environment-specific configuration files.
+///
+/// For any setting that appears in both the `app.toml` and the environment-specific file, the latter will override the former so that default settings can be kept in `app.toml` that are overridden per environment if necessary.
 #[derive(Deserialize, Clone, Debug)]
 pub struct Config {
     pub server: ServerConfig,
@@ -23,7 +28,7 @@ pub struct Config {
 ///
 /// This struct keeps all settings specific to the server – currently that is the interface the server binds to
 /// but more might be added in the future. The struct is provided pre-defined by Pacesetter and cannot be changed. It
-/// **must** be used for the `server` field in the application-specific `Config` struct:
+/// **must** be used for the `server` field in the application-specific [`Config`] struct:
 ///
 /// ```rust
 /// #[derive(Deserialize, Clone, Debug)]
@@ -73,7 +78,7 @@ impl ServerConfig {
 ///
 /// This struct keeps all settings specific to the database – currently that is the database URL to use to connect to the database
 /// but more might be added in the future. The struct is provided pre-defined by Pacesetter and cannot be changed. It
-/// **must** be used for the `database` field in the application-specific `Config` struct:
+/// **must** be used for the `database` field in the application-specific [`Config`] struct:
 ///
 /// ```rust
 /// #[derive(Deserialize, Clone, Debug)]

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -124,6 +124,7 @@ pub struct DatabaseConfig {
 /// All application-specific configuration is read from the respective configuration files in
 /// the `config/app.toml` and `config/environments/<environment>.toml` files such that settings
 /// in the latter override settings in the former.
+#[doc(hidden)]
 pub fn load_config<'a, T>(env: &Environment) -> Result<T, anyhow::Error>
 where
     T: Deserialize<'a>,
@@ -164,6 +165,7 @@ where
 /// Aspects of the application might behave differently based on the currently active environment.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
+#[doc(hidden)]
 pub enum Environment {
     Development,
     Production,
@@ -190,6 +192,7 @@ impl Display for Environment {
 /// ```
 ///
 /// "dev" and "development" are parsed as [`Environment::Development`], "prod" and "production" are parsed as [`Environment::Production`] and "test" is parsed as [`Environment::Test`]. Parsing environments is case-insensitive.
+#[doc(hidden)]
 pub fn get_env() -> Result<Environment, anyhow::Error> {
     match env::var("APP_ENVIRONMENT") {
         Ok(val) => {

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -97,38 +97,6 @@ pub struct DatabaseConfig {
 }
 {%- endunless %}
 
-/// Loads the application's configuration.
-///
-/// Examples:
-/// ```rust
-/// use my_app_config::Config;
-/// use pacesetter::{get_env, load_config};
-///
-/// let env = get_env();
-/// let config: Config = load_config(&env);
-/// ```
-///
-/// The returned `Config` struct is defined in the `config` crate, e.g.
-///
-/// ```rust
-/// #[derive(Deserialize, Debug)]
-/// pub struct Config {
-///     pub server: ServerConfig,
-{% unless template_type == "minimal" -%}
-///     pub database: DatabaseConfig,
-{%- endunless %}
-///
-///     pub app_setting: String,
-/// }
-/// ```
-///
-/// For the Development and Test environment, this function will define environment variables
-/// based on the contents of the `.env` and `.env.test` files respectively. `.env` files are
-/// ignored in the production environment.
-///
-/// All application-specific configuration is read from the respective configuration files in
-/// the `config/app.toml` and `config/environments/<environment>.toml` files such that settings
-/// in the latter override settings in the former.
 #[doc(hidden)]
 pub fn load_config<'a, T>(env: &Environment) -> Result<T, anyhow::Error>
 where
@@ -165,10 +133,6 @@ where
     Ok(config)
 }
 
-/// The environment the application runs in – either Development, Production, or Test.
-///
-/// Aspects of the application might behave differently based on the currently active environment.
-#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
 #[doc(hidden)]
 pub enum Environment {
@@ -187,16 +151,6 @@ impl Display for Environment {
     }
 }
 
-/// Gets the [`Environment`] from the `APP_ENVIRONMENT` environment variable or defaults to [`Environment::Development`] if that is not set.
-///
-/// Example
-/// ```rust
-/// assert_eq!(env::var("APP_ENVIRONMENT"), Ok("dev"));
-/// let env = get_env();
-/// assert_eq!(env, Environment::Development);
-/// ```
-///
-/// "dev" and "development" are parsed as [`Environment::Development`], "prod" and "production" are parsed as [`Environment::Production`] and "test" is parsed as [`Environment::Test`]. Parsing environments is case-insensitive.
 #[doc(hidden)]
 pub fn get_env() -> Result<Environment, anyhow::Error> {
     match env::var("APP_ENVIRONMENT") {

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -185,7 +185,10 @@ pub fn get_env() -> Result<Environment, anyhow::Error> {
     }
 }
 
-pub(crate) fn parse_env(env: &str) -> Result<Environment, anyhow::Error> {
+/// Parses an [`Environment`] from a string.
+///
+/// The environment can be passed in different forms, e.g. "dev", "development", "prod", etc. If an invalid environment is passed, an error is returned.
+pub fn parse_env(env: &str) -> Result<Environment, anyhow::Error> {
     let env = &env.to_lowercase();
     match env.as_str() {
         "dev" => Ok(Environment::Development),

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -1,3 +1,5 @@
+//! The {{project-name}}-config crate contains functionality for parsing as well as accessing the project's documentation.
+
 use anyhow::{anyhow, Context};
 use dotenvy::dotenv;
 use figment::{
@@ -17,8 +19,10 @@ use tracing::info;
 /// For any setting that appears in both the `app.toml` and the environment-specific file, the latter will override the former so that default settings can be kept in `app.toml` that are overridden per environment if necessary.
 #[derive(Deserialize, Clone, Debug)]
 pub struct Config {
+    /// the server configuration: [`ServerConfig`]
     pub server: ServerConfig,
     {% unless template_type == "minimal" -%}
+    /// the database configuration: [`DatabaseConfig`]
     pub database: DatabaseConfig,
     {%- endunless %}
     // add your config settings here…

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -106,6 +106,7 @@ pub struct DatabaseConfig {
 /// Depending on the environment, this function will behave differently:
 /// * for [`Environment::Development`], the function will load env vars from a `.env` file at the project root if that is present
 /// * for [`Environment::Test`], the function will load env vars from a `.env.test` file at the project root if that is present
+/// * for [`Environment::Production`], the function will only use the process env vars, and not load a `.env` file
 ///
 /// Configuration settings are loaded from these sources (in that order so that latter soruces override former):
 /// * the `config/app.toml` file

--- a/blueprint/config/src/lib.rs.liquid
+++ b/blueprint/config/src/lib.rs.liquid
@@ -101,7 +101,16 @@ pub struct DatabaseConfig {
 }
 {%- endunless %}
 
-#[doc(hidden)]
+/// Loads the application configuration for a particular environment.
+///
+/// Depending on the environment, this function will behave differently:
+/// * for [`Environment::Development`], the function will load env vars from a `.env` file at the project root if that is present
+/// * for [`Environment::Test`], the function will load env vars from a `.env.test` file at the project root if that is present
+///
+/// Configuration settings are loaded from these sources (in that order so that latter soruces override former):
+/// * the `config/app.toml` file
+/// * the `config/environments/<development|production|test>.toml` files depending on the environment
+/// * environment variables
 pub fn load_config<'a, T>(env: &Environment) -> Result<T, anyhow::Error>
 where
     T: Deserialize<'a>,
@@ -137,11 +146,16 @@ where
     Ok(config)
 }
 
+/// The environment the application runs in.
+///
+/// The application can run in 3 different environments: development, production, and test. Depending on the environment, the configuration might be different (e.g. different databases) or the application might behave differently.
 #[derive(Debug, Clone, PartialEq)]
-#[doc(hidden)]
 pub enum Environment {
+    /// The development environment is what developers would use locally.
     Development,
+    /// The production environment would typically be used in the released, user-facing deployment of the app.
     Production,
+    /// The test environment is using when running e.g. `cargo test`
     Test,
 }
 
@@ -155,7 +169,9 @@ impl Display for Environment {
     }
 }
 
-#[doc(hidden)]
+/// Returns the currently active environment.
+///
+/// If the `APP_ENVIRONMENT` env var is set, the application environment is parsed from that (which might fail if an invalid environment is set). If the env var is not set, [`Environment::Development`] is returned.
 pub fn get_env() -> Result<Environment, anyhow::Error> {
     match env::var("APP_ENVIRONMENT") {
         Ok(val) => {

--- a/blueprint/db/Cargo.toml.liquid
+++ b/blueprint/db/Cargo.toml.liquid
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
+# examples in docs don't run without a running database, etc.
 doctest = false
 
 [features]

--- a/blueprint/db/Cargo.toml.liquid
+++ b/blueprint/db/Cargo.toml.liquid
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lib]
+doctest = false
+
 [features]
 test-helpers = ["dep:fake", "dep:rand", "dep:regex"]
 

--- a/blueprint/db/src/entities/mod.rs.liquid
+++ b/blueprint/db/src/entities/mod.rs.liquid
@@ -1,4 +1,6 @@
 {% if template_type == 'full' %}
+/// All functionality related to the [`Task`] entity
 pub mod tasks;
+/// All functionality related to the [`User`] entity
 pub mod users;
 {%- endif %}

--- a/blueprint/db/src/entities/mod.rs.liquid
+++ b/blueprint/db/src/entities/mod.rs.liquid
@@ -1,6 +1,6 @@
 {% if template_type == 'full' %}
-/// All functionality related to the [`Task`] entity
+/// All functionality related to the [`tasks::Task`] entity
 pub mod tasks;
-/// All functionality related to the [`User`] entity
+/// All functionality related to the [`users::User`] entity
 pub mod users;
 {%- endif %}

--- a/blueprint/db/src/entities/tasks.rs
+++ b/blueprint/db/src/entities/tasks.rs
@@ -6,20 +6,34 @@ use sqlx::Postgres;
 use uuid::Uuid;
 use validator::Validate;
 
+/// A task, i.e. TODO item.
 #[derive(Serialize, Debug, Deserialize)]
 pub struct Task {
+    /// The id of the record.
     pub id: Uuid,
+    /// The description, i.e. what to do.
     pub description: String,
 }
 
+/// A changeset representing the data that is intended to be used to either create a new task or update an existing task.
+///
+/// Changesets are validatated in the [`create`] and [`update`] functions which return an [Result::Err] if validation fails.
+///
+/// Changesets can also be used to generate fake data for tests when the `test-helpers` feature is enabled:
+///
+/// ```
+/// let task_changeset: TaskChangeset = Faker.fake();
+/// ```
 #[derive(Deserialize, Validate, Clone)]
 #[cfg_attr(feature = "test-helpers", derive(Serialize, Dummy))]
 pub struct TaskChangeset {
+    /// The description must be at least 1 character long.
     #[cfg_attr(feature = "test-helpers", dummy(faker = "Sentence(3..8)"))]
     #[validate(length(min = 1))]
     pub description: String,
 }
 
+/// Load all [`Task`]s from the database.
 pub async fn load_all(
     executor: impl sqlx::Executor<'_, Database = Postgres>,
 ) -> Result<Vec<Task>, anyhow::Error> {
@@ -29,6 +43,9 @@ pub async fn load_all(
     Ok(tasks)
 }
 
+/// Load one [`Task`] from the database identified by its ID.
+///
+/// If no record can be found for the ID, a [`crate::Error::NoRecordFound`] will be returned.
 pub async fn load(
     id: Uuid,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
@@ -43,6 +60,9 @@ pub async fn load(
     }
 }
 
+/// Delete a [`Task`] from the database identified by its ID.
+///
+/// If no record can be found for the ID, a [`crate::Error::NoRecordFound`] will be returned.
 pub async fn delete(
     id: Uuid,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
@@ -57,6 +77,9 @@ pub async fn delete(
     }
 }
 
+/// Create a task in the database with the data in the passed [`TaskChangeset`].
+///
+/// If the data in the changeset isn't valid, a [`crate::Error::ValidationError`] will be returned, otherwise the created task is returned.
 pub async fn create(
     task: TaskChangeset,
     executor: impl sqlx::Executor<'_, Database = Postgres>,
@@ -77,6 +100,9 @@ pub async fn create(
     })
 }
 
+/// Updates a task in the database with the data in the passed [`TaskChangeset`].
+///
+/// If the data in the changeset isn't valid, a [`crate::Error::ValidationError`] will be returned, otherwise the updated [`Task`] is returned. If no record can be found for the ID, a [`crate::Error::NoRecordFound`] will be returned.
 pub async fn update(
     id: Uuid,
     task: TaskChangeset,

--- a/blueprint/db/src/entities/users.rs
+++ b/blueprint/db/src/entities/users.rs
@@ -2,12 +2,18 @@ use serde::Serialize;
 use sqlx::Postgres;
 use uuid::Uuid;
 
+/// A user record.
 #[derive(Serialize, Debug, Clone)]
 pub struct User {
+    /// The id of the record.
     pub id: Uuid,
+    /// The user's name.
     pub name: String,
 }
 
+/// Loads a user based on the passed token.
+///
+/// If no user exists for the token, [`Option::None`] is returned, otherwise [`Option::Some(User)`] is returned.
 pub async fn load_with_token(
     token: &str,
     executor: impl sqlx::Executor<'_, Database = Postgres>,

--- a/blueprint/db/src/entities/users.rs
+++ b/blueprint/db/src/entities/users.rs
@@ -13,7 +13,7 @@ pub struct User {
 
 /// Loads a user based on the passed token.
 ///
-/// If no user exists for the token, [`Option::None`] is returned, otherwise [`Option::Some(User)`] is returned.
+/// If no user exists for the token, [`Option::None`] is returned, otherwise `Option::Some(User)` is returned.
 pub async fn load_with_token(
     token: &str,
     executor: impl sqlx::Executor<'_, Database = Postgres>,

--- a/blueprint/db/src/lib.rs
+++ b/blueprint/db/src/lib.rs
@@ -7,6 +7,7 @@ pub use sqlx::postgres::PgPool as DbPool;
 
 pub mod entities;
 
+#[doc(hidden)]
 pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Error> {
     let pool = PgPoolOptions::new()
         .connect(config.url.as_str())

--- a/blueprint/db/src/lib.rs
+++ b/blueprint/db/src/lib.rs
@@ -5,18 +5,24 @@ use thiserror::Error;
 
 pub use sqlx::postgres::PgPool as DbPool;
 
+/// Entity definitions and related functions
 pub mod entities;
 
-#[doc(hidden)]
-pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Error> {
-    let pool = PgPoolOptions::new()
-        .connect(config.url.as_str())
-        .await
-        .context("Failed to connect to database")?;
-
-    Ok(pool)
-}
-
+/// Starts a new database transaction.
+///
+/// Example:
+/// ```
+/// let tx = transaction(&app_state.db_pool).await?;
+/// tasks::create(task_data, &mut *tx)?;
+/// users::create(user_data, &mut *tx)?;
+/// 
+/// match tx.commit().await {
+///     Ok(_) => Ok((StatusCode::CREATED, Json(results))),
+///     Err(e) => Err((internal_error(e), "".into())),
+/// }
+/// ```
+///
+/// Transactions are rolled back automatically when they are dropped without having been committed.
 pub async fn transaction(
     db_pool: &DbPool,
 ) -> Result<Transaction<'static, Postgres>, anyhow::Error> {
@@ -28,15 +34,30 @@ pub async fn transaction(
     Ok(tx)
 }
 
+/// Errors that can occur as a result of a data layer operation.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// General database error, e.g. communicating with the database failed
     #[error("database query failed")]
     DbError(anyhow::Error),
+    /// No record was found where one was expected, e.g. when loading a record by ID
     #[error("no record found where one was expected")]
     NoRecordFound,
     #[error("validation failed")]
+    /// An invalid changeset was passed to a writing operation such as creating or updating a record.
     ValidationError(validator::ValidationErrors),
 }
 
-#[cfg(feature = "test-helpers")]
+#[doc(hidden)]
+pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Error> {
+    let pool = PgPoolOptions::new()
+        .connect(config.url.as_str())
+        .await
+        .context("Failed to connect to database")?;
+
+    Ok(pool)
+}
+
+#[cfg(any(feature = "test-helpers", doc))]
+#[doc(cfg(feature = "test-helpers"))]
 pub mod test_helpers;

--- a/blueprint/db/src/lib.rs
+++ b/blueprint/db/src/lib.rs
@@ -1,3 +1,5 @@
+//! The {{project-name}}-db crate contains all code related to database access: entities, migrations, functions for validating and reading and writing data.
+
 use anyhow::{Context, Result};
 use {{crate_name}}_config::DatabaseConfig;
 use sqlx::{postgres::PgPoolOptions, Postgres, Transaction};
@@ -48,7 +50,7 @@ pub enum Error {
     ValidationError(validator::ValidationErrors),
 }
 
-#[doc(hidden)]
+/// Creates a connection pool to the database specified in the passed [`{{project-name}}-config::DatabaseConfig`]
 pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Error> {
     let pool = PgPoolOptions::new()
         .connect(config.url.as_str())
@@ -58,5 +60,6 @@ pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Erro
     Ok(pool)
 }
 
+/// Functionality for working with data that is only relevant in tests but not as part of the normal application flow.
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;

--- a/blueprint/db/src/lib.rs
+++ b/blueprint/db/src/lib.rs
@@ -58,6 +58,5 @@ pub async fn connect_pool(config: DatabaseConfig) -> Result<DbPool, anyhow::Erro
     Ok(pool)
 }
 
-#[cfg(any(feature = "test-helpers", doc))]
-#[doc(cfg(feature = "test-helpers"))]
+#[cfg(feature = "test-helpers")]
 pub mod test_helpers;

--- a/blueprint/db/src/test_helpers/mod.rs.liquid
+++ b/blueprint/db/src/test_helpers/mod.rs.liquid
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 {% if template_type == 'full' %}
-/// All test functionality related to the [`{{project-name}}-db::entities::users::User`] entity
+/// All test functionality related to the [`crate::entities::users::User`] entity
 pub mod users;
 {%- endif %}
 

--- a/blueprint/db/src/test_helpers/mod.rs.liquid
+++ b/blueprint/db/src/test_helpers/mod.rs.liquid
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 {% if template_type == 'full' %}
-/// All test functionality related to the [`{{crate_name}}_db::entities::users::User`] entity
+/// All test functionality related to the [`{{project-name}}-db::entities::users::User`] entity
 pub mod users;
 {%- endif %}
 

--- a/blueprint/db/src/test_helpers/mod.rs.liquid
+++ b/blueprint/db/src/test_helpers/mod.rs.liquid
@@ -9,9 +9,14 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 {% if template_type == 'full' %}
+/// All test functionality related to the [`User`] entity
 pub mod users;
 {%- endif %}
 
+/// Sets up a dedicated database to be used in a test case.
+///
+/// This sets up a dedicated database as a fork of the main test database as configured in `.env.test`. The database can be used in a test case to ensure the test case is isolated from other test cases. The function returns a connection pool connected to the created database.
+/// This function is automatically called by the [`{{project-name}}-macros::db_test`] macro. The return connection pool is passed to the test case via the [`{{project-name}}-macros::DbTestContext`].
 #[allow(unused)]
 pub async fn setup_db(config: &DatabaseConfig) -> DbPool {
     let test_db_config = prepare_db(config).await;
@@ -20,6 +25,9 @@ pub async fn setup_db(config: &DatabaseConfig) -> DbPool {
         .expect("Could not connect to database!")
 }
 
+/// Drops a dedicated database for a test case.
+///
+/// This function is automatically called by the [`{{project-name}}-macros::db_test`] macro. It ensures test-specific database are cleaned up after each test run so we don't end up with large numbers of unused databases.
 pub async fn teardown_db(db_pool: DbPool) {
     let mut connect_options = db_pool.connect_options();
     let db_config = Arc::make_mut(&mut connect_options);
@@ -35,7 +43,7 @@ pub async fn teardown_db(db_pool: DbPool) {
     connection.execute(query.as_str()).await.unwrap();
 }
 
-pub async fn prepare_db(config: &DatabaseConfig) -> DatabaseConfig {
+async fn prepare_db(config: &DatabaseConfig) -> DatabaseConfig {
     let db_config = parse_db_config(&config.url);
     let db_name = db_config.get_database().unwrap();
 

--- a/blueprint/db/src/test_helpers/mod.rs.liquid
+++ b/blueprint/db/src/test_helpers/mod.rs.liquid
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 {% if template_type == 'full' %}
-/// All test functionality related to the [`entities::users::User`] entity
+/// All test functionality related to the [`{{crate_name}}_db::entities::users::User`] entity
 pub mod users;
 {%- endif %}
 

--- a/blueprint/db/src/test_helpers/mod.rs.liquid
+++ b/blueprint/db/src/test_helpers/mod.rs.liquid
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 {% if template_type == 'full' %}
-/// All test functionality related to the [`users::User`] entity
+/// All test functionality related to the [`entities::users::User`] entity
 pub mod users;
 {%- endif %}
 

--- a/blueprint/db/src/test_helpers/mod.rs.liquid
+++ b/blueprint/db/src/test_helpers/mod.rs.liquid
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 {% if template_type == 'full' %}
-/// All test functionality related to the [`User`] entity
+/// All test functionality related to the [`users::User`] entity
 pub mod users;
 {%- endif %}
 

--- a/blueprint/db/src/test_helpers/users.rs
+++ b/blueprint/db/src/test_helpers/users.rs
@@ -2,14 +2,28 @@ use crate::entities::users::User;
 use fake::{faker::name::en::*, Dummy};
 use sqlx::postgres::PgPool;
 
+/// A changeset representing the data that is intended to be used to either create a new user or update an existing user.
+///
+/// Changesets are validatated in the [`create`] and [`update`] functions which return an [Result::Err] if validation fails.
+///
+/// Changesets can also be used to generate fake data for tests when the `test-helpers` feature is enabled:
+///
+/// ```
+/// let user_changeset: UserChangeset = Faker.fake();
+/// ```
 #[derive(Debug, Clone, Dummy)]
 pub struct UserChangeset {
+    /// The user's name
     #[dummy(faker = "Name()")]
     pub name: String,
+    /// The user's auth token, fake data will be a 100 characters long number
     #[dummy(faker = "100..101")]
     pub token: String,
 }
 
+/// Creates a user in the database with the data in the passed [`UserChangeset`].
+///
+/// If the data in the changeset isn't valid, a [`crate::Error::ValidationError`] will be returned, otherwise the created user is returned.
 pub async fn create(user: UserChangeset, db: &PgPool) -> Result<User, anyhow::Error> {
     let record = sqlx::query!(
         "INSERT INTO users (name, token) VALUES ($1, $2) RETURNING id",

--- a/blueprint/db/src/test_helpers/users.rs
+++ b/blueprint/db/src/test_helpers/users.rs
@@ -4,7 +4,7 @@ use sqlx::postgres::PgPool;
 
 /// A changeset representing the data that is intended to be used to either create a new user or update an existing user.
 ///
-/// Changesets are validatated in the [`create`] and [`update`] functions which return an [Result::Err] if validation fails.
+/// Changesets are validated in the [`create`] function which return an [Result::Err] if validation fails.
 ///
 /// Changesets can also be used to generate fake data for tests when the `test-helpers` feature is enabled:
 ///

--- a/blueprint/macros/Cargo.toml.liquid
+++ b/blueprint/macros/Cargo.toml.liquid
@@ -6,6 +6,7 @@ publish = false
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 quote = "1.0"

--- a/blueprint/macros/Cargo.toml.liquid
+++ b/blueprint/macros/Cargo.toml.liquid
@@ -6,6 +6,7 @@ publish = false
 
 [lib]
 proc-macro = true
+# examples in docs don't run without a running database, etc.
 doctest = false
 
 [dependencies]

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -1,4 +1,4 @@
-//! The {{project-name}}-macros crate contains the `test`{%- unless template_type == "minimal" %} and `db_test`{%- endunless %} macro{%- unless template_type == "minimal" -%} s{% endunless -%}.
+//! The {{crate_name}}-macros crate contains the `test`{%- unless template_type == "minimal" %} and `db_test`{%- endunless %} macro{%- unless template_type == "minimal" -%} s{% endunless -%}.
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -17,7 +17,7 @@ use syn::{parse_macro_input, ItemFn};
 /// }
 /// ```
 ///
-/// Test functions marked with this attribute receive a [`{{project-name}}-web::test_helpers::TestContext`] struct via which they get access a preconfigured instance of the application. The application instance is extended with convenience methods for making requests from the test.
+/// Test functions marked with this attribute receive a [`{{crate_name}}-web::test_helpers::TestContext`] struct via which they get access a preconfigured instance of the application. The application instance is extended with convenience methods for making requests from the test.
 #[proc_macro_attribute]
 pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
@@ -75,7 +75,7 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Test functions marked with this attribute receive a [`{{project-name}}-web::test_helpers::DbTestContext`] struct via which they get access a preconfigured instance of the application as well as a pool of database connections. The connection pool is connected to the dedicated database for this single test case. The application instance is configured to be connected to the same database so that data created in the test is accessible to the application and vice versa (see in the example how a task is created in the task, which the application reads and responds with as JSON). That allows full-stack testing without interfering with other tests.
+/// Test functions marked with this attribute receive a [`{{crate_name}}-web::test_helpers::DbTestContext`] struct via which they get access a preconfigured instance of the application as well as a pool of database connections. The connection pool is connected to the dedicated database for this single test case. The application instance is configured to be connected to the same database so that data created in the test is accessible to the application and vice versa (see in the example how a task is created in the task, which the application reads and responds with as JSON). That allows full-stack testing without interfering with other tests.
 ///
 /// The test-specific database is cleaned up automatically so that no manual cleanup is necessary.
 #[proc_macro_attribute]

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -1,7 +1,23 @@
+//! The {{project-name}}-macros crate contains the `test`{%- unless template_type == "minimal" %} and `db_test`{%- endunless %} macro{%- unless template_type == "minimal" -%} s{% endunless -%}.
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, ItemFn};
 
+/// Used to mark an application test.
+///
+/// Example:
+/// ```
+/// #[test]
+/// async fn test_hello(context: &TestContext) {
+///     let response = context.app.request("/greet").send().await;
+/// 
+///     let greeting: Greeting = response.into_body().into_json().await;
+///     assert_that!(greeting.hello, eq(String::from("world")));
+/// }
+/// ```
+///
+/// Test functions marked with this attribute receive a [`TestContext`] struct via which they get access a preconfigured instance of the application. The application instance is extended with convenience methods for making requests from the test.
 #[proc_macro_attribute]
 pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
@@ -30,6 +46,38 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 {% unless template_type == "minimal" -%}
+/// Used to mark an application test.
+///
+/// Example:
+/// ```
+/// #[db_test]
+/// async fn test_read_all(context: &DbTestContext) {
+///     let task_changeset: TaskChangeset = Faker.fake();
+///     create_task(task_changeset.clone(), &context.db_pool)
+///         .await
+///         .unwrap();
+/// 
+///     let response = context
+///         .app
+///         .request("/tasks")
+///         .method(Method::GET)
+///         .send()
+///         .await;
+/// 
+///     assert_that!(response.status(), eq(StatusCode::OK));
+/// 
+///     let tasks: TasksList = response.into_body().into_json::<TasksList>().await;
+///     assert_that!(tasks, len(eq(1)));
+///     assert_that!(
+///         tasks.first().unwrap().description,
+///         eq(task_changeset.description)
+///     );
+/// }
+/// ```
+///
+/// Test functions marked with this attribute receive a [`DbTestContext`] struct via which they get access a preconfigured instance of the application as well as a pool of database connections. The connection pool is connected to the dedicated database for this single test case. The application instance is configured to be connected to the same database so that data created in the test is accessible to the application and vice versa (see in the example how a task is created in the task, which the application reads and responds with as JSON). That allows full-stack testing without interfering with other tests.
+///
+/// The test-specific database is cleaned up automatically so that no manual cleanup is necessary.
 #[proc_macro_attribute]
 pub fn db_test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -4,6 +4,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, ItemFn};
 
+#[allow(clippy::test_attr_in_doctest)]
 /// Used to mark an application test.
 ///
 /// Example:

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -4,7 +4,6 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, ItemFn};
 
-#[allow(clippy::test_attr_in_doctest)]
 /// Used to mark an application test.
 ///
 /// Example:

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -18,7 +18,7 @@ use syn::{parse_macro_input, ItemFn};
 /// }
 /// ```
 ///
-/// Test functions marked with this attribute receive a [`TestContext`] struct via which they get access a preconfigured instance of the application. The application instance is extended with convenience methods for making requests from the test.
+/// Test functions marked with this attribute receive a [`{{project-name}}-web::test_helpers::TestContext`] struct via which they get access a preconfigured instance of the application. The application instance is extended with convenience methods for making requests from the test.
 #[proc_macro_attribute]
 pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
@@ -76,7 +76,7 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Test functions marked with this attribute receive a [`DbTestContext`] struct via which they get access a preconfigured instance of the application as well as a pool of database connections. The connection pool is connected to the dedicated database for this single test case. The application instance is configured to be connected to the same database so that data created in the test is accessible to the application and vice versa (see in the example how a task is created in the task, which the application reads and responds with as JSON). That allows full-stack testing without interfering with other tests.
+/// Test functions marked with this attribute receive a [`{{project-name}}-web::test_helpers::DbTestContext`] struct via which they get access a preconfigured instance of the application as well as a pool of database connections. The connection pool is connected to the dedicated database for this single test case. The application instance is configured to be connected to the same database so that data created in the test is accessible to the application and vice versa (see in the example how a task is created in the task, which the application reads and responds with as JSON). That allows full-stack testing without interfering with other tests.
 ///
 /// The test-specific database is cleaned up automatically so that no manual cleanup is necessary.
 #[proc_macro_attribute]

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -31,7 +31,7 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
     );
 
     let setup = quote! {
-        let context = crate::common::setup().await;
+        let context = {{crate_name}}_web::test_helpers::setup().await;
     };
 
     let output = quote!(
@@ -91,11 +91,11 @@ pub fn db_test(_: TokenStream, item: TokenStream) -> TokenStream {
     );
 
     let setup = quote! {
-        let context = crate::common::setup_with_db().await;
+        let context = {{crate_name}}_web::test_helpers::setup_with_db().await;
     };
 
     let teardown = quote! {
-        crate::common::teardown_with_db(context).await;
+        {{crate_name}}_web::test_helpers::teardown_with_db(context).await;
     };
 
     let output = quote!(

--- a/blueprint/macros/src/lib.rs.liquid
+++ b/blueprint/macros/src/lib.rs.liquid
@@ -91,11 +91,11 @@ pub fn db_test(_: TokenStream, item: TokenStream) -> TokenStream {
     );
 
     let setup = quote! {
-        let context = {{crate_name}}_web::test_helpers::setup_with_db().await;
+        let context = {{crate_name}}_web::test_helpers::setup().await;
     };
 
     let teardown = quote! {
-        {{crate_name}}_web::test_helpers::teardown_with_db(context).await;
+        {{crate_name}}_web::test_helpers::teardown(context).await;
     };
 
     let output = quote!(

--- a/blueprint/web/Cargo.toml.liquid
+++ b/blueprint/web/Cargo.toml.liquid
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
+# examples in docs don't run without a running database, etc.
 doctest = false
 
 [features]

--- a/blueprint/web/Cargo.toml.liquid
+++ b/blueprint/web/Cargo.toml.liquid
@@ -7,6 +7,9 @@ publish = false
 [lib]
 doctest = false
 
+[features]
+test-helpers = ["dep:serde_json", "dep:tower", "dep:hyper", "dep:{{project-name}}-macros"]
+
 [dependencies]
 anyhow = "1.0"
 axum = "0.7"
@@ -23,14 +26,15 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "f
 {% unless template_type == "minimal" -%}
 uuid = { version = "1.6", features = ["serde"] }
 {%- endunless %}
+serde_json = { version = "1.0", optional = true }
+tower = { version = "0.5", features = ["util"], optional = true }
+hyper = { version = "1.0", features = ["full"], optional = true }
+{{project-name}}-macros = { path = "../macros", optional = true }
 
 [dev-dependencies]
 fake = "2.9"
 googletest = "0.11"
-serde_json = "1.0"
-tower = { version = "0.5", features = ["util"] }
-hyper = { version = "1.0", features = ["full"] }
 {% unless template_type == "minimal" -%}
 {{project-name}}-db = { path = "../db", features = ["test-helpers"] }
 {%- endunless %}
-{{project-name}}-macros = { path = "../macros" }
+{{project-name}}-web = { path = ".", features = ["test-helpers"] }

--- a/blueprint/web/README.md.liquid
+++ b/blueprint/web/README.md.liquid
@@ -22,7 +22,7 @@ The `AppState` struct can be freely extended with custom fields.
 Routes are defined in `src/routes.rs`, e.g.:
 
 ```rs
-pub fn routes(app_state: AppState) -> Router {
+pub fn init_routes(app_state: AppState) -> Router {
 Router::new()
     .route("/tasks", post(create_task))
     .route("/tasks", get(get_tasks))

--- a/blueprint/web/README.md.liquid
+++ b/blueprint/web/README.md.liquid
@@ -69,3 +69,7 @@ async fn test_hello(context: &TestContext) {
     assert_that!(greeting.hello, eq(String::from("world")));
 }
 {% endif -%}
+
+### Test helpers
+
+The {{project-name}}-web crate includes test helpers in `src/test_helpers` that add a number of convience functions for easier issuing of requests and parsing of responses. Those helpers depend on the `test-helpers` feature flag which is automatically enabled when running tests but not for production builds. _You should not need to make any changes to these helpers._

--- a/blueprint/web/src/controllers/greeting.rs
+++ b/blueprint/web/src/controllers/greeting.rs
@@ -1,11 +1,14 @@
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
+/// A greeting to respond with to the requesting client
 #[derive(Deserialize, Serialize)]
 pub struct Greeting {
+    /// Who do we say hello to?
     pub hello: String,
 }
 
+/// Responds with a [`Greeting`], encoded as JSON.
 pub async fn hello() -> Json<Greeting> {
     Json(Greeting {
         hello: String::from("world"),

--- a/blueprint/web/src/controllers/mod.rs.liquid
+++ b/blueprint/web/src/controllers/mod.rs.liquid
@@ -1,6 +1,8 @@
 {% if template_type == "full" -%}
+#[doc(hidden)]
 pub mod tasks;
 {%- endif %}
 {% if template_type == "minimal" -%}
+#[doc(hidden)]
 pub mod greeting;
 {%- endif %}

--- a/blueprint/web/src/controllers/mod.rs.liquid
+++ b/blueprint/web/src/controllers/mod.rs.liquid
@@ -1,8 +1,8 @@
 {% if template_type == "full" -%}
-#[doc(hidden)]
+/// All endpoints for managing tasks
 pub mod tasks;
 {%- endif %}
 {% if template_type == "minimal" -%}
-#[doc(hidden)]
+/// An endpoint to greet the requesting client
 pub mod greeting;
 {%- endif %}

--- a/blueprint/web/src/controllers/tasks.rs
+++ b/blueprint/web/src/controllers/tasks.rs
@@ -4,6 +4,9 @@ use {{crate_name}}_db::{entities::tasks, transaction, Error};
 use tracing::info;
 use uuid::Uuid;
 
+/// Creates a task in the database.
+///
+/// This function creates a task in the database (see [`{{crate_name}}_db::entities::tasks::create`]) based on a [`{{crate_name}}_db::entities::tasks::TaskChangeset`] (sent as JSON). If the task is created successfully, a 201 response is returned with the created [`{{crate_name}}_db::entities::tasks::Task`]'s JSON representation in the response body. If the changeset is invalid, a 422 response is returned.
 pub async fn create(
     State(app_state): State<AppState>,
     Json(task): Json<tasks::TaskChangeset>,
@@ -18,6 +21,11 @@ pub async fn create(
     }
 }
 
+/// Creates multiple tasks in the database.
+///
+/// This function creates multiple tasks in the database (see [`{{crate_name}}_db::entities::tasks::create`]) based on [`{{crate_name}}_db::entities::tasks::TaskChangeset`]s (sent as JSON). If all tasks are created successfully, a 201 response is returned with the created [`{{crate_name}}_db::entities::tasks::Task`]s' JSON representation in the response body. If any of the passed changesets is invalid, a 422 response is returned.
+///
+/// This function creates all tasks in a transaction so that either all are created successfully or none is.
 pub async fn create_batch(
     State(app_state): State<AppState>,
     Json(tasks): Json<Vec<tasks::TaskChangeset>>,
@@ -45,6 +53,9 @@ pub async fn create_batch(
     }
 }
 
+/// Reads and responds with all the tasks currently present in the database.
+///
+/// This function reads all [`{{crate_name}}_db::entities::tasks::Task`]s from the database (see [`{{crate_name}}_db::entities::tasks::load_all`]) and responds with their JSON representations.
 pub async fn read_all(
     State(app_state): State<AppState>,
 ) -> Result<Json<Vec<tasks::Task>>, StatusCode> {
@@ -57,6 +68,9 @@ pub async fn read_all(
     Ok(Json(tasks))
 }
 
+/// Reads and responds with a task identified by its ID.
+///
+/// This function reads one [`{{crate_name}}_db::entities::tasks::Task`] identified by its ID from the database (see [`{{crate_name}}_db::entities::tasks::load`]) and responds with its JSON representations. If no task is found for the ID, a 404 response is returned.
 pub async fn read_one(
     State(app_state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -68,6 +82,9 @@ pub async fn read_one(
     }
 }
 
+/// Updates a task in the database.
+///
+/// This function updates a task identified by its ID in the database (see [`{{crate_name}}_db::entities::tasks::update`]) with the data from the passed [`{{crate_name}}_db::entities::tasks::TaskChangeset`] (sent as JSON). If the task is updated successfully, a 200 response is returned with the created [`{{crate_name}}_db::entities::tasks::Task`]'s JSON representation in the response body. If the changeset is invalid, a 422 response is returned.
 pub async fn update(
     State(app_state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -84,6 +101,9 @@ pub async fn update(
     }
 }
 
+/// Deletes a task identified by its ID from the database.
+///
+/// This function deletes one [`{{crate_name}}_db::entities::tasks::Task`] identified by the entity's id from the database (see [`{{crate_name}}_db::entities::tasks::delete`]) and responds with a 204 status code and empty response body. If no task is found for the ID, a 404 response is returned.
 pub async fn delete(
     State(app_state): State<AppState>,
     Path(id): Path<Uuid>,

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -7,13 +7,24 @@ use tracing::info;
 use tracing_panic::panic_hook;
 use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
+/// The application's controllers that implement request handlers.
 pub mod controllers;
+/// Middlewares that incoming requests are passed through before being passed to [`controllers`].
 pub mod middlewares;
-#[doc(hidden)]
+/// Contains the application's route definitions.
 pub mod routes;
+/// Contains the application state definition and functionality to initialize it.
 pub mod state;
 
-#[doc(hidden)]
+/// Runs the application.
+///
+/// thus function does all the work to initiatilize and run the application:
+///
+/// 1. Determine the environment the application is running in (see [`{{crate_name}}_config::get_env`])
+/// 2. Load the configuration (see [`{{crate_name}}_config::load_config`])
+/// 3. Initialize the application state (see [`state::app_state`])
+/// 4. Initialize the application's router (see [`routes::routes`])
+/// 5. Boot the application and start listening for requests on the configured interface and port
 pub async fn run() -> anyhow::Result<()> {
     let env = get_env().context("Cannot get environment!")?;
     let config: Config = load_config(&env).context("Cannot load config!")?;
@@ -71,7 +82,6 @@ where
 /// * registers a [`tracing_panic::panic_hook`]
 ///
 /// The function respects the `RUST_LOG` if set or defaults to filtering spans and events with level [`tracing_subscriber::filter::LevelFilter::INFO`] and higher.
-#[doc(hidden)]
 pub fn init_tracing() {
     let filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -22,14 +22,14 @@ pub mod state;
 ///
 /// 1. Determine the environment the application is running in (see [`{{crate_name}}_config::get_env`])
 /// 2. Load the configuration (see [`{{crate_name}}_config::load_config`])
-/// 3. Initialize the application state (see [`state::app_state`])
+/// 3. Initialize the application state (see [`state::init_app_state`])
 /// 4. Initialize the application's router (see [`routes::routes`])
 /// 5. Boot the application and start listening for requests on the configured interface and port
 pub async fn run() -> anyhow::Result<()> {
     let env = get_env().context("Cannot get environment!")?;
     let config: Config = load_config(&env).context("Cannot load config!")?;
 
-    let app_state = state::app_state(config.clone()).await;
+    let app_state = state::init_app_state(config.clone()).await;
     let app = routes::routes(app_state);
 
     let addr = config.server.addr();

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -1,3 +1,5 @@
+//! The {{crate_name}}-web crate contains the application's web interface, mainly in the form of controllers implementing HTTP endpoints. It also includes the application tests that are black-box tests, interfacing with the application like any other HTTP client.
+
 use anyhow::Context;
 use axum::{serve, http::StatusCode};
 use {{crate_name}}_config::{Config, get_env, load_config};

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -9,9 +9,11 @@ use tracing_subscriber::{filter::EnvFilter, fmt, layer::SubscriberExt, util::Sub
 
 pub mod controllers;
 pub mod middlewares;
+#[doc(hidden)]
 pub mod routes;
 pub mod state;
 
+#[doc(hidden)]
 pub async fn run() -> anyhow::Result<()> {
     let env = get_env().context("Cannot get environment!")?;
     let config: Config = load_config(&env).context("Cannot load config!")?;
@@ -69,6 +71,7 @@ where
 /// * registers a [`tracing_panic::panic_hook`]
 ///
 /// The function respects the `RUST_LOG` if set or defaults to filtering spans and events with level [`tracing_subscriber::filter::LevelFilter::INFO`] and higher.
+#[doc(hidden)]
 pub fn init_tracing() {
     let filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -83,3 +83,7 @@ pub fn init_tracing() {
 
     std::panic::set_hook(Box::new(panic_hook));
 }
+
+#[cfg(feature = "test-helpers")]
+pub mod test_helpers;
+

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -94,6 +94,6 @@ pub fn init_tracing() {
     std::panic::set_hook(Box::new(panic_hook));
 }
 
+/// Helpers that simplify writing application tests.
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;
-

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -1,4 +1,4 @@
-//! The {{crate_name}}-web crate contains the application's web interface, mainly in the form of controllers implementing HTTP endpoints. It also includes the application tests that are black-box tests, interfacing with the application like any other HTTP client.
+//! The {{crate_name}}_web crate contains the application's web interface which mainly are controllers implementing HTTP endpoints. It also includes the application tests that are black-box tests, interfacing with the application like any other HTTP client.
 
 use anyhow::Context;
 use axum::{serve, http::StatusCode};

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -23,14 +23,14 @@ pub mod state;
 /// 1. Determine the environment the application is running in (see [`{{crate_name}}_config::get_env`])
 /// 2. Load the configuration (see [`{{crate_name}}_config::load_config`])
 /// 3. Initialize the application state (see [`state::init_app_state`])
-/// 4. Initialize the application's router (see [`routes::routes`])
+/// 4. Initialize the application's router (see [`routes::init_routes`])
 /// 5. Boot the application and start listening for requests on the configured interface and port
 pub async fn run() -> anyhow::Result<()> {
     let env = get_env().context("Cannot get environment!")?;
     let config: Config = load_config(&env).context("Cannot load config!")?;
 
     let app_state = state::init_app_state(config.clone()).await;
-    let app = routes::routes(app_state);
+    let app = routes::init_routes(app_state);
 
     let addr = config.server.addr();
     let listener = TcpListener::bind(&addr).await?;

--- a/blueprint/web/src/lib.rs
+++ b/blueprint/web/src/lib.rs
@@ -20,7 +20,7 @@ pub mod state;
 
 /// Runs the application.
 ///
-/// thus function does all the work to initiatilize and run the application:
+/// This function does all the work to initiatilize and run the application:
 ///
 /// 1. Determine the environment the application is running in (see [`{{crate_name}}_config::get_env`])
 /// 2. Load the configuration (see [`{{crate_name}}_config::load_config`])

--- a/blueprint/web/src/main.rs
+++ b/blueprint/web/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use {{crate_name}}_web::{init_tracing, run};
 
 #[tokio::main]

--- a/blueprint/web/src/middlewares/auth.rs
+++ b/blueprint/web/src/middlewares/auth.rs
@@ -9,6 +9,9 @@ use axum::{
 use {{crate_name}}_db::entities::users;
 use tracing::Span;
 
+/// Authenticates an incoming request based on an auth token.
+///
+/// This looks for a token in the `Authorization` header. If no token is present or no user exists with that token (see [`{{crate_name}}_db::entities::users::load_with_token`]), a 401 response code is returned and the request is not processed further.
 #[tracing::instrument(skip_all, fields(rejection_reason = tracing::field::Empty))]
 pub async fn auth(
     State(app_state): State<AppState>,

--- a/blueprint/web/src/middlewares/mod.rs.liquid
+++ b/blueprint/web/src/middlewares/mod.rs.liquid
@@ -1,3 +1,4 @@
 {% if template_type == "full" -%}
+#[doc(hidden)]
 pub mod auth;
 {%- endif %}

--- a/blueprint/web/src/middlewares/mod.rs.liquid
+++ b/blueprint/web/src/middlewares/mod.rs.liquid
@@ -1,4 +1,4 @@
 {% if template_type == "full" -%}
-#[doc(hidden)]
+/// Authentication middleware
 pub mod auth;
 {%- endif %}

--- a/blueprint/web/src/routes.rs.liquid
+++ b/blueprint/web/src/routes.rs.liquid
@@ -2,11 +2,7 @@
 use crate::state::AppState;
 use axum::Router;
 
-pub fn routes(app_state: AppState) -> Router {
-    Router::new().with_state(app_state)
-}
-{%- endif %}
-{% if template_type == "full" -%}
+{% elsif template_type == "full" -%}
 use crate::controllers::tasks::{
     create as create_task, create_batch as create_tasks, delete as delete_task,
     read_all as get_tasks, read_one as get_task, update as update_task,
@@ -18,8 +14,16 @@ use axum::{
     routing::{delete, get, post, put},
     Router,
 };
+{%- elsif template_type == "minimal" %}
+use crate::controllers::greeting::hello;
+use crate::state::AppState;
+use axum::{routing::get, Router};
+{%- endif %}
 
 pub fn routes(app_state: AppState) -> Router {
+{% if template_type == "default" -%}
+    Router::new().with_state(app_state)
+{% elsif template_type == "full" -%}
     Router::new()
         .route("/tasks", post(create_task))
         .route("/tasks", put(create_tasks))
@@ -29,16 +33,9 @@ pub fn routes(app_state: AppState) -> Router {
         .route("/tasks", get(get_tasks))
         .route("/tasks/:id", get(get_task))
         .with_state(app_state)
-}
-{%- endif %}
-{% if template_type == "minimal" -%}
-use crate::controllers::greeting::hello;
-use crate::state::AppState;
-use axum::{routing::get, Router};
-
-pub fn routes(app_state: AppState) -> Router {
+{%- elsif template_type == "minimal" %}
     Router::new()
-            .route("/greet", get(hello))
-            .with_state(app_state)
-}
+        .route("/greet", get(hello))
+        .with_state(app_state)
 {%- endif %}
+}

--- a/blueprint/web/src/routes.rs.liquid
+++ b/blueprint/web/src/routes.rs.liquid
@@ -20,6 +20,9 @@ use crate::state::AppState;
 use axum::{routing::get, Router};
 {%- endif %}
 
+/// Initializes the application's routes.
+///
+/// This function maps paths (e.g. "/greet") and HTTP methods (e.g. "GET") to functions in [`crate::controllers`] as well as includes middlewares defined in [`crate::middlewares`] into the routing layer (see [`axum::Router`]).
 pub fn init_routes(app_state: AppState) -> Router {
 {% if template_type == "default" -%}
     Router::new().with_state(app_state)

--- a/blueprint/web/src/routes.rs.liquid
+++ b/blueprint/web/src/routes.rs.liquid
@@ -20,7 +20,7 @@ use crate::state::AppState;
 use axum::{routing::get, Router};
 {%- endif %}
 
-pub fn routes(app_state: AppState) -> Router {
+pub fn init_routes(app_state: AppState) -> Router {
 {% if template_type == "default" -%}
     Router::new().with_state(app_state)
 {% elsif template_type == "full" -%}

--- a/blueprint/web/src/state.rs.liquid
+++ b/blueprint/web/src/state.rs.liquid
@@ -11,6 +11,7 @@ pub struct AppState {
 }
 
 {% if template_type != "minimal" %}
+#[doc(hidden)]
 pub async fn app_state(config: Config) -> AppState {
     let db_pool = connect_pool(config.database)
         .await

--- a/blueprint/web/src/state.rs.liquid
+++ b/blueprint/web/src/state.rs.liquid
@@ -3,15 +3,19 @@ use {{crate_name}}_config::Config;
 use {{crate_name}}_db::{connect_pool, DbPool};
 {%- endunless %}
 
+/// The application's state that is available in [`crate::controllers`] and [`crate::middlewares`].
 #[derive(Clone)]
 pub struct AppState {
     {% unless template_type == "minimal" -%}
+    /// The database pool that's used to get a connection to the application's database (see [`{{crate_name}}_db::DbPool`]).
     pub db_pool: DbPool,
     {%- endunless %}
 }
 
+/// Initializes the application state.
+///
+/// This function creates an [`AppState`] based on the current [`{{crate_name}}_config::Config`].
 {% if template_type != "minimal" %}
-#[doc(hidden)]
 pub async fn app_state(config: Config) -> AppState {
     let db_pool = connect_pool(config.database)
         .await

--- a/blueprint/web/src/state.rs.liquid
+++ b/blueprint/web/src/state.rs.liquid
@@ -16,7 +16,7 @@ pub struct AppState {
 ///
 /// This function creates an [`AppState`] based on the current [`{{crate_name}}_config::Config`].
 {% if template_type != "minimal" %}
-pub async fn app_state(config: Config) -> AppState {
+pub async fn init_app_state(config: Config) -> AppState {
     let db_pool = connect_pool(config.database)
         .await
         .expect("Could not connect to database!");
@@ -24,7 +24,7 @@ pub async fn app_state(config: Config) -> AppState {
     AppState { db_pool }
 }
 {% else %}
-pub async fn app_state(_config: Config) -> AppState {
+pub async fn init_app_state(_config: Config) -> AppState {
     AppState {}
 }
 {%- endif %}

--- a/blueprint/web/src/test_helpers/mod.rs.liquid
+++ b/blueprint/web/src/test_helpers/mod.rs.liquid
@@ -245,6 +245,7 @@ pub async fn teardown(context: DbTestContext) {
     teardown_db(context.db_pool);
 }
 {% else %}
+#[allow(clippy::test_attr_in_doctest)]
 /// Provides context information for application tests.
 ///
 /// A `TestContext` is passed as an argument to tests marked with the [`{{crate_name}}_macros::test`] attribute macro. It is used to access the application under test.

--- a/blueprint/web/src/test_helpers/mod.rs.liquid
+++ b/blueprint/web/src/test_helpers/mod.rs.liquid
@@ -125,7 +125,7 @@ pub struct DbTestContext {
 }
 
 #[allow(unused)]
-pub async fn setup_with_db() -> DbTestContext {
+pub async fn setup() -> DbTestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
     let config = init_config.get_or_init(|| load_config(&Environment::Test).unwrap());
 
@@ -142,7 +142,7 @@ pub async fn setup_with_db() -> DbTestContext {
 }
 
 #[allow(unused)]
-pub async fn teardown_with_db(context: DbTestContext) {
+pub async fn teardown(context: DbTestContext) {
     drop(context.app);
 
     teardown_db(context.db_pool);

--- a/blueprint/web/src/test_helpers/mod.rs.liquid
+++ b/blueprint/web/src/test_helpers/mod.rs.liquid
@@ -135,7 +135,10 @@ pub async fn setup_with_db() -> DbTestContext {
         db_pool: test_db_pool.clone(),
     });
 
-    build_db_test_context(app, test_db_pool)
+    DbTestContext {
+        app,
+        db_pool: test_db_pool,
+    }
 }
 
 #[allow(unused)]
@@ -144,21 +147,24 @@ pub async fn teardown_with_db(context: DbTestContext) {
 
     teardown_db(context.db_pool);
 }
-
-pub fn build_db_test_context(router: Router, db_pool: DbPool) -> DbTestContext {
-    DbTestContext {
-        app: router,
-        db_pool,
-    }
-}
 {% else %}
+/// Provides context for application tests.
+///
+/// A `TestContext` is passed as an argument to tests marked with the [`{{crate_name}}_macros::test`] attribute macro. It is used to access the application under test.
+///
+/// Example:
+/// ```
+/// #[test]
+/// async fn test_hello(context: &TestContext) {
+///     let response = context.app.request("/greet").send().await;
+/// 
+///     let greeting: Greeting = response.into_body().into_json().await;
+///     assert_that!(greeting.hello, eq(String::from("world")));
+/// }
+/// ```
 pub struct TestContext {
     /// The application that is being tested.
     pub app: Router,
-}
-
-pub fn build_test_context(router: Router) -> TestContext {
-    TestContext { app: router }
 }
 
 pub async fn setup() -> TestContext {
@@ -167,6 +173,6 @@ pub async fn setup() -> TestContext {
 
     let app = init_routes(AppState {});
 
-    build_test_context(app)
+    TestContext { app }
 }
 {%- endif %}

--- a/blueprint/web/src/test_helpers/mod.rs.liquid
+++ b/blueprint/web/src/test_helpers/mod.rs.liquid
@@ -11,12 +11,12 @@ use {{crate_name}}_db::{
     test_helpers::{setup_db, teardown_db},
     DbPool,
 };
-use crate::routes::routes;
+use crate::routes::init_routes;
 use crate::state::AppState;
 use std::cell::OnceCell;
 {%- else -%}
 use {{crate_name}}_config::{load_config, Config, Environment};
-use crate::routes::routes;
+use crate::routes::init_routes;
 use crate::state::AppState;
 use std::cell::OnceCell;
 {%- endif -%}
@@ -131,7 +131,7 @@ pub async fn setup_with_db() -> DbTestContext {
 
     let test_db_pool = setup_db(&config.database).await;
 
-    let app = routes(AppState {
+    let app = init_routes(AppState {
         db_pool: test_db_pool.clone(),
     });
 
@@ -165,7 +165,7 @@ pub async fn setup() -> TestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
     let _config = init_config.get_or_init(|| load_config(&Environment::Test).unwrap());
 
-    let app = routes(AppState {});
+    let app = init_routes(AppState {});
 
     build_test_context(app)
 }

--- a/blueprint/web/src/test_helpers/mod.rs.liquid
+++ b/blueprint/web/src/test_helpers/mod.rs.liquid
@@ -22,6 +22,19 @@ use std::cell::OnceCell;
 {%- endif -%}
 use tower::ServiceExt;
 
+/// A request that a test sends to the application.
+///
+/// TestRequests are constructed via the test context (see {%- if template_type != "minimal" -%}[`DbTestContext`]{%- else -%}[`TestContext`]{%- endif -%}).
+///
+/// Example:
+/// ```
+/// let response = context
+///     .app
+///     .request("/greet")
+///     .method(Method::GET)
+///     .send()
+///     .await;
+/// ```
 pub struct TestRequest {
     router: Router,
     uri: String,
@@ -41,24 +54,51 @@ impl TestRequest {
         }
     }
 
+    /// Sets the HTTP method for the request, e.g. GET or POST, see [`axum::http::Method`].
     #[allow(unused)]
     pub fn method(mut self, method: Method) -> Self {
         self.method = method;
         self
     }
 
+    /// Adds an HTTP header to the request.
+    ///
+    /// Header names must be passed as [`hyper::header::HeaderName`] while values can be passed as [`&str`]s.
+    ///
+    /// Example:
+    /// ```
+    /// let response = context
+    ///     .app
+    ///     .request("/greet")
+    ///     .method(Method::GET)
+    ///     .header(.header(http::header::CONTENT_TYPE, "application/json"))
+    ///     .await;
+    /// ```
     #[allow(unused)]
     pub fn header(mut self, name: HeaderName, value: &str) -> Self {
         self.headers.insert(name, value.parse().unwrap());
         self
     }
 
+    /// Sets the body for the request.
+    ///
+    /// Example:
+    /// ```
+    /// let response = context
+    ///     .app
+    ///     .request("/tasks")
+    ///     .method(Method::POST)
+    ///     .body(Body::from(json!({
+    ///         "description": "get milk!",
+    ///     }).to_string()))
+    /// ```
     #[allow(unused)]
     pub fn body(mut self, body: Body) -> Self {
         self.body = body;
         self
     }
 
+    /// Sends the request to the application under test.
     #[allow(unused)]
     pub async fn send(self) -> Response {
         let mut request_builder = Request::builder().uri(&self.uri);
@@ -75,7 +115,9 @@ impl TestRequest {
     }
 }
 
+/// Testing convenience functions for [`axum::Router`].
 pub trait RouterExt {
+    /// Creates a [`TestRequest`] pointed at the application under test.
     #[allow(unused)]
     fn request(&self, uri: &str) -> TestRequest;
 }
@@ -87,10 +129,25 @@ impl RouterExt for Router {
     }
 }
 
+/// Testing convenience functions for [`axum::body::Body`].
 pub trait BodyExt {
+    /// Returns the body as raw bytes.
     #[allow(unused, async_fn_in_trait)]
     async fn into_bytes(self) -> Bytes;
 
+    /// Returns the body as parsed JSON.
+    ///
+    /// Example:
+    /// ```
+    /// let response = context
+    ///     .app
+    ///     .request("/tasks")
+    ///     .method(Method::GET)
+    ///     .send()
+    ///     .await;
+    ///
+    /// let tasks: Vec<Task> = response.into_body().into_json::<Vec<Task>>().await;
+    /// ```
     #[allow(unused, async_fn_in_trait)]
     async fn into_json<T>(self) -> T
     where
@@ -117,6 +174,36 @@ impl BodyExt for Body {
 }
 
 {%- if template_type != "minimal" -%}
+/// Provides context information for application tests.
+///
+/// A `DbTestContext` is passed as an argument to tests marked with the [`{{crate_name}}_macros::db_test`] attribute macro. It is used to access the application under test as well as the database (which is the same database the application under test uses).
+///
+/// Example:
+/// ```
+/// #[db_test]
+/// async fn test_read_all(context: &DbTestContext) {
+///     let task_changeset: TaskChangeset = Faker.fake();
+///     create_task(task_changeset.clone(), &context.db_pool)
+///         .await
+///         .unwrap();
+///
+///     let response = context
+///         .app
+///         .request("/tasks")
+///         .method(Method::GET)
+///         .send()
+///         .await;
+///
+///     assert_that!(response.status(), eq(StatusCode::OK));
+///
+///     let tasks: TasksList = response.into_body().into_json::<TasksList>().await;
+///     assert_that!(tasks, len(eq(1)));
+///     assert_that!(
+///         tasks.first().unwrap().description,
+///         eq(task_changeset.description)
+///     );
+/// }
+/// ```
 pub struct DbTestContext {
     /// The application that is being tested.
     pub app: Router,
@@ -124,6 +211,11 @@ pub struct DbTestContext {
     pub db_pool: DbPool,
 }
 
+/// Sets up a test and returns a [`DbTestContext`] configured for the particular test case.
+///
+/// This function initializes a new instance of the application under test using the configuration for [`{{crate_name}}_config::Environment::Test`]. The application is configured to use the same database that is also made available to the test itself via the test context. That database is a clone of the main test database that is only used by the particular test case to ensure isolation between test cases. It is automatically torn down after the test case completes (see [`teardown`]).
+///
+/// This function is not invoked directly but used inside of the [`{{crate_name}}_macros::db_test`] attribute macro. The test context is automatically passed to test cases marked with that macro as an argument.
 #[allow(unused)]
 pub async fn setup() -> DbTestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
@@ -141,6 +233,11 @@ pub async fn setup() -> DbTestContext {
     }
 }
 
+/// Tears down a [`DbTestContext`].
+///
+/// This function drops the test-case specific database set up by [`setup`].
+///
+/// This function is not invoked directly but used inside of the [`{{crate_name}}_macros::db_test`] attribute macro. The test context is automatically passed to test cases marked with that macro as an argument.
 #[allow(unused)]
 pub async fn teardown(context: DbTestContext) {
     drop(context.app);
@@ -148,7 +245,7 @@ pub async fn teardown(context: DbTestContext) {
     teardown_db(context.db_pool);
 }
 {% else %}
-/// Provides context for application tests.
+/// Provides context information for application tests.
 ///
 /// A `TestContext` is passed as an argument to tests marked with the [`{{crate_name}}_macros::test`] attribute macro. It is used to access the application under test.
 ///
@@ -167,6 +264,11 @@ pub struct TestContext {
     pub app: Router,
 }
 
+/// Sets up a test and returns a [`TestContext`].
+///
+/// This function initializes a new instance of the application under test using the configuration for [`{{crate_name}}_config::Environment::Test`].
+///
+/// This function is not invoked directly but used inside of the [`{{crate_name}}_macros::test`] attribute macro. The test context is automatically passed to test cases marked with that macro as an argument.
 pub async fn setup() -> TestContext {
     let init_config: OnceCell<Config> = OnceCell::new();
     let _config = init_config.get_or_init(|| load_config(&Environment::Test).unwrap());

--- a/blueprint/web/src/test_helpers/mod.rs.liquid
+++ b/blueprint/web/src/test_helpers/mod.rs.liquid
@@ -11,13 +11,13 @@ use {{crate_name}}_db::{
     test_helpers::{setup_db, teardown_db},
     DbPool,
 };
-use {{crate_name}}_web::routes::routes;
-use {{crate_name}}_web::state::AppState;
+use crate::routes::routes;
+use crate::state::AppState;
 use std::cell::OnceCell;
 {%- else -%}
 use {{crate_name}}_config::{load_config, Config, Environment};
-use {{crate_name}}_web::routes::routes;
-use {{crate_name}}_web::state::AppState;
+use crate::routes::routes;
+use crate::state::AppState;
 use std::cell::OnceCell;
 {%- endif -%}
 use tower::ServiceExt;
@@ -88,10 +88,10 @@ impl RouterExt for Router {
 }
 
 pub trait BodyExt {
-    #[allow(unused)]
+    #[allow(unused, async_fn_in_trait)]
     async fn into_bytes(self) -> Bytes;
 
-    #[allow(unused)]
+    #[allow(unused, async_fn_in_trait)]
     async fn into_json<T>(self) -> T
     where
         T: serde::de::DeserializeOwned;

--- a/blueprint/web/tests/api/greeting_test.rs.liquid
+++ b/blueprint/web/tests/api/greeting_test.rs.liquid
@@ -1,4 +1,4 @@
-use crate::common::{BodyExt, RouterExt, TestContext};
+use {{crate_name}}_web::test_helpers::{BodyExt, RouterExt, TestContext};
 use googletest::prelude::*;
 use {{crate_name}}_macros::test;
 use {{crate_name}}_web::controllers::greeting::Greeting;

--- a/blueprint/web/tests/api/main.rs.liquid
+++ b/blueprint/web/tests/api/main.rs.liquid
@@ -1,4 +1,3 @@
-mod common;
 {% if template_type == "full" -%}
 mod tasks_test;
 {%- endif %}

--- a/blueprint/web/tests/api/tasks_test.rs.liquid
+++ b/blueprint/web/tests/api/tasks_test.rs.liquid
@@ -1,4 +1,4 @@
-use crate::common::{BodyExt, DbTestContext, RouterExt};
+use {{crate_name}}_web::test_helpers::{BodyExt, DbTestContext, RouterExt};
 use axum::{
     body::Body,
     http::{self, Method},

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::error::Error;
 
 use vergen::EmitBuilder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 //! Pacesetter provides blueprints and generators for axum projects. It establishes a standard project structure with a folder layout, standard patterns for composing applications into e.g. database access and web API, running tests and migrations, as well as tracing.
 
 use anyhow::Context;


### PR DESCRIPTION
This adds docs and comments to the code itself to give guidance for what to insert where, etc.

- [x] `config` crate
- [x] `cli` crate
- [x] `db` crate
  - [x] make it so that running `cargo doc` in the workspace root creates docs for the elements behind the `db` crate's `test-helpers` feature flag as well (can only be done via documentation to pass `--workspace --all-features` to `cargo doc` but that's good enough)
  - [x] add code comments on functions and entities of example application
- [x] `macro` crate
  - [x] fix links to `TestContext` and `DbTestContext` in `web` crate
- [x] `web` crate
- [x] go over and review all docs for spelling, writing improvability etc.