### PR TITLE
don't fail if into_json of TestResponse is never used

### DIFF
--- a/blueprint/web/tests/api/common.rs.liquid
+++ b/blueprint/web/tests/api/common.rs.liquid
@@ -91,6 +91,7 @@ pub trait BodyExt {
     #[allow(unused)]
     async fn into_bytes(self) -> Bytes;
 
+    #[allow(unused)]
     async fn into_json<T>(self) -> T
     where
         T: serde::de::DeserializeOwned;


### PR DESCRIPTION
…since that can happen if e.g. an empty app is generated fresh or the API never returns JSON.

I assume this only comes up now because of a new Clippy version on CI or so…