### PR TITLE
run CI daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request: {}
+  schedule:
+    - cron:  '0 3 * * *' # daily, at 3am
 
 jobs:
   rustfmt:


### PR DESCRIPTION
…so we identify issues with dependencies early (the blueprints don't include Cargo.lock files so patch versions dependencies might change any time, potentially causing errors)